### PR TITLE
Use compiler_builtins for mem{cmp,cpy,move,set}

### DIFF
--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -17,6 +17,7 @@ libm = "0.2.1"
 rsix = "0.22.3"
 memoffset = "0.6"
 realpath-ext = "0.1.0"
+compiler_builtins = "0.1.50"
 
 # A minimal `global_allocator` implementation.
 wee_alloc = "0.4.5"


### PR DESCRIPTION
As proposed in #5. This is just a straightforward code replacement, I'm not sure what else if anything needs to be done. I've left `bcmp` as-is since I can't see any reason to use `compiler_builtins` there.