### PR TITLE
Call out to the memchr crate for memchr and memrchr

### DIFF
--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -18,6 +18,7 @@ rsix = "0.22.3"
 memoffset = "0.6"
 realpath-ext = "0.1.0"
 compiler_builtins = "0.1.50"
+memchr = "2.4.1"
 
 # A minimal `global_allocator` implementation.
 wee_alloc = "0.4.5"

--- a/c-scape/src/c.rs
+++ b/c-scape/src/c.rs
@@ -875,27 +875,25 @@ pub unsafe extern "C" fn free(ptr: *mut c_void) {
 // mem
 
 #[no_mangle]
-pub unsafe extern "C" fn memchr(s: *mut c_void, c: c_int, len: usize) -> *mut c_void {
+pub unsafe extern "C" fn memchr(s: *const c_void, c: c_int, len: usize) -> *mut c_void {
     libc!(memchr(s, c, len));
 
-    for i in 0..len {
-        if *s.cast::<u8>().add(i) == c as u8 {
-            return s.cast::<u8>().add(i).cast::<c_void>();
-        }
+    let slice: &[u8] = slice::from_raw_parts(s.cast(), len);
+    match memchr::memchr(c as u8, slice) {
+        None => null_mut(),
+        Some(i) => s.cast::<u8>().add(i) as *mut c_void,
     }
-    null_mut()
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn memrchr(s: *mut c_void, c: c_int, len: usize) -> *mut c_void {
+pub unsafe extern "C" fn memrchr(s: *const c_void, c: c_int, len: usize) -> *mut c_void {
     libc!(memrchr(s, c, len));
 
-    for i in 0..len {
-        if *s.cast::<u8>().add(len - i - 1) == c as u8 {
-            return s.cast::<u8>().add(len - i - 1).cast::<c_void>();
-        }
+    let slice: &[u8] = slice::from_raw_parts(s.cast(), len);
+    match memchr::memrchr(c as u8, slice) {
+        None => null_mut(),
+        Some(i) => s.cast::<u8>().add(i) as *mut c_void,
     }
-    null_mut()
 }
 
 #[no_mangle]


### PR DESCRIPTION
See #5.

Note: I've changed the signatures of `memchr` and `memrchr` to match the (weird) C signatures, which take a const pointer but return a mut pointer ([e.g.](https://man7.org/linux/man-pages/man3/memchr.3p.html)).