### PR TITLE
Go back to explicitly defining `memcpy` etc.

### DIFF
--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -17,7 +17,7 @@ libm = "0.2.1"
 rsix = "0.22.4"
 memoffset = "0.6"
 realpath-ext = "0.1.0"
-compiler_builtins = "0.1.50"
+compiler_builtins = { version = "0.1.50", features = ["mem", "mangled-names"] }
 memchr = "2.4.1"
 
 # A minimal `global_allocator` implementation.

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -2,6 +2,7 @@
 #![no_builtins] // don't let LLVM optimize our `memcpy` into a `memcpy` call
 #![feature(asm)]
 #![feature(c_variadic)] // for `ioctl` etc.
+#![feature(rustc_private)] // for compiler-builtins
 #![cfg(target_vendor = "mustang")]
 
 #[cfg(mustang_use_libc)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -59,6 +59,25 @@ fn test_example(name: &str, features: &str, stdout: &str, stderr: &str) {
         name,
         output
     );
+
+    // test-backtrace and test-tls are not fully supported by mustang yet.
+    // test-initialize-c-runtime deliberately links in C runtime symbols.
+    if name != "test-backtrace" && name != "test-tls" && name != "test-initialize-c-runtime" {
+        let output = Command::new("nm")
+            .arg("-u")
+            .arg(&format!(
+                "target/{}-mustang-linux-gnu/debug/examples/{}",
+                arch, name
+            ))
+            .output()
+            .unwrap();
+        assert_eq!(
+            "",
+            String::from_utf8_lossy(&output.stdout),
+            "example {} had unexpected undefined symbols",
+            name
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Referencing "memcpy" and other symbols from `__mustang_c_scape__c`
didn't turn out to be sufficient to ensure they'd be linked in from
compiler-builtins, and not from the host libc.

Switch back to explicitly defining `memcpy` etc., though still use
compiler-builtins to do the work. This requires us to use
`#[feature(rustc_private)]` for now, but fortunately the things we're
depending on should be relatively stable in practice.

Also add a test for this.