### PR TITLE
Basic networking support.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,15 +24,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [ubuntu, ubuntu-16.04, ubuntu-18.04, i686-linux, aarch64-linux]
+        build: [ubuntu, ubuntu-18.04, i686-linux, aarch64-linux]
         include:
           - build: ubuntu
             os: ubuntu-latest
-            rust: nightly
-            host_target: x86_64-unknown-linux-gnu
-            mustang_target: x86_64-mustang-linux-gnu
-          - build: ubuntu-16.04
-            os: ubuntu-16.04
             rust: nightly
             host_target: x86_64-unknown-linux-gnu
             mustang_target: x86_64-mustang-linux-gnu

--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ set the environment variable `CC_i686-mustang-linux-gnu` to
 
 Known limitations in `mustang` include:
 
- - Networking functionality that depends on `getsockopt`, `setsockopt`, and
-   `getaddrinfo` is not implemented yet.
  - Spawning new processes, threads, and unwinding panics are
    not implemented yet.
  - No support for dynamic linking yet.

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -14,11 +14,12 @@ edition = "2018"
 once_cell = "1.8.0"
 smallvec = "1.6.1"
 libm = "0.2.1"
-rsix = "0.23.0"
+rsix = "0.23.4"
 memoffset = "0.6"
 realpath-ext = "0.1.0"
 compiler_builtins = { version = "0.1.50", features = ["mem", "mangled-names"] }
 memchr = "2.4.1"
+sync-resolve = { git = "https://github.com/sunfishcode/sync-resolve/" }
 
 # A minimal `global_allocator` implementation.
 wee_alloc = "0.4.5"

--- a/c-scape/src/data/linux_gnu.rs
+++ b/c-scape/src/data/linux_gnu.rs
@@ -1,6 +1,8 @@
 // Constants and types used in `*-*-linux-gnu` targets. These are
 // checked against `libc` by the parent mod.rs.
 
+#![allow(dead_code)]
+
 use std::ffi::c_void;
 use std::os::raw::{c_int, c_long};
 
@@ -28,7 +30,7 @@ pub(crate) const ALIGNOF_MAXALIGN_T: usize = 16;
 
 pub(crate) const MAP_ANONYMOUS: i32 = 32;
 
-pub(crate) const MAP_FAILED: *mut c_void = -1_isize as usize as *mut c_void;
+pub(crate) const MAP_FAILED: *mut c_void = !0_usize as *mut c_void;
 
 pub(crate) const _SC_PAGESIZE: c_int = 30;
 pub(crate) const _SC_GETPW_R_SIZE_MAX: c_int = 70;
@@ -55,6 +57,174 @@ pub(crate) const SHUT_RD: c_int = 0;
 pub(crate) const SHUT_WR: c_int = 1;
 pub(crate) const SHUT_RDWR: c_int = 2;
 
+// `getsockopt`/`setsockopt` options.
+
+pub(crate) const SOL_SOCKET: c_int = 1;
+
+pub(crate) const IPPROTO_IP: c_int = 0;
+pub(crate) const IPPROTO_TCP: c_int = 6;
+pub(crate) const IPPROTO_IPV6: c_int = 41;
+
+pub(crate) const SO_DEBUG: c_int = 1;
+pub(crate) const SO_REUSEADDR: c_int = 2;
+pub(crate) const SO_TYPE: c_int = 3;
+pub(crate) const SO_ERROR: c_int = 4;
+pub(crate) const SO_DONTROUTE: c_int = 5;
+pub(crate) const SO_BROADCAST: c_int = 6;
+pub(crate) const SO_SNDBUF: c_int = 7;
+pub(crate) const SO_RCVBUF: c_int = 8;
+pub(crate) const SO_KEEPALIVE: c_int = 9;
+pub(crate) const SO_OOBINLINE: c_int = 10;
+pub(crate) const SO_NO_CHECK: c_int = 11;
+pub(crate) const SO_PRIORITY: c_int = 12;
+pub(crate) const SO_LINGER: c_int = 13;
+pub(crate) const SO_BSDCOMPAT: c_int = 14;
+pub(crate) const SO_REUSEPORT: c_int = 15;
+pub(crate) const SO_PASSCRED: c_int = 16;
+pub(crate) const SO_PEERCRED: c_int = 17;
+pub(crate) const SO_RCVLOWAT: c_int = 18;
+pub(crate) const SO_SNDLOWAT: c_int = 19;
+pub(crate) const SO_ACCEPTCONN: c_int = 30;
+pub(crate) const SO_PEERSEC: c_int = 31;
+pub(crate) const SO_SNDBUFFORCE: c_int = 32;
+pub(crate) const SO_RCVBUFFORCE: c_int = 33;
+pub(crate) const SO_PROTOCOL: c_int = 38;
+pub(crate) const SO_DOMAIN: c_int = 39;
+pub(crate) const SO_RCVTIMEO: c_int = 20;
+pub(crate) const SO_SNDTIMEO: c_int = 21;
+pub(crate) const SO_RCVTIMEO_NEW: c_int = 66;
+pub(crate) const SO_SNDTIMEO_NEW: c_int = 67;
+
+pub(crate) const IP_TOS: c_int = 1;
+pub(crate) const IP_TTL: c_int = 2;
+pub(crate) const IP_HDRINCL: c_int = 3;
+pub(crate) const IP_OPTIONS: c_int = 4;
+pub(crate) const IP_ROUTER_ALERT: c_int = 5;
+pub(crate) const IP_RECVOPTS: c_int = 6;
+pub(crate) const IP_RETOPTS: c_int = 7;
+pub(crate) const IP_PKTINFO: c_int = 8;
+pub(crate) const IP_PKTOPTIONS: c_int = 9;
+pub(crate) const IP_MTU_DISCOVER: c_int = 10;
+pub(crate) const IP_RECVERR: c_int = 11;
+pub(crate) const IP_RECVTTL: c_int = 12;
+pub(crate) const IP_RECVTOS: c_int = 13;
+pub(crate) const IP_MTU: c_int = 14;
+pub(crate) const IP_FREEBIND: c_int = 15;
+pub(crate) const IP_IPSEC_POLICY: c_int = 16;
+pub(crate) const IP_XFRM_POLICY: c_int = 17;
+pub(crate) const IP_PASSSEC: c_int = 18;
+pub(crate) const IP_TRANSPARENT: c_int = 19;
+pub(crate) const IP_ORIGDSTADDR: c_int = 20;
+pub(crate) const IP_MINTTL: c_int = 21;
+pub(crate) const IP_NODEFRAG: c_int = 22;
+pub(crate) const IP_CHECKSUM: c_int = 23;
+pub(crate) const IP_BIND_ADDRESS_NO_PORT: c_int = 24;
+pub(crate) const IP_RECVFRAGSIZE: c_int = 25;
+pub(crate) const IP_MULTICAST_IF: c_int = 32;
+pub(crate) const IP_MULTICAST_TTL: c_int = 33;
+pub(crate) const IP_MULTICAST_LOOP: c_int = 34;
+pub(crate) const IP_ADD_MEMBERSHIP: c_int = 35;
+pub(crate) const IP_DROP_MEMBERSHIP: c_int = 36;
+pub(crate) const IP_UNBLOCK_SOURCE: c_int = 37;
+pub(crate) const IP_BLOCK_SOURCE: c_int = 38;
+pub(crate) const IP_ADD_SOURCE_MEMBERSHIP: c_int = 39;
+pub(crate) const IP_DROP_SOURCE_MEMBERSHIP: c_int = 40;
+pub(crate) const IP_MSFILTER: c_int = 41;
+pub(crate) const IP_MULTICAST_ALL: c_int = 49;
+pub(crate) const IP_UNICAST_IF: c_int = 50;
+
+pub(crate) const IPV6_ADDRFORM: c_int = 1;
+pub(crate) const IPV6_2292PKTINFO: c_int = 2;
+pub(crate) const IPV6_2292HOPOPTS: c_int = 3;
+pub(crate) const IPV6_2292DSTOPTS: c_int = 4;
+pub(crate) const IPV6_2292RTHDR: c_int = 5;
+pub(crate) const IPV6_2292PKTOPTIONS: c_int = 6;
+pub(crate) const IPV6_CHECKSUM: c_int = 7;
+pub(crate) const IPV6_2292HOPLIMIT: c_int = 8;
+pub(crate) const IPV6_NEXTHOP: c_int = 9;
+pub(crate) const IPV6_AUTHHDR: c_int = 10;
+pub(crate) const IPV6_UNICAST_HOPS: c_int = 16;
+pub(crate) const IPV6_MULTICAST_IF: c_int = 17;
+pub(crate) const IPV6_MULTICAST_HOPS: c_int = 18;
+pub(crate) const IPV6_MULTICAST_LOOP: c_int = 19;
+pub(crate) const IPV6_ADD_MEMBERSHIP: c_int = 20;
+pub(crate) const IPV6_DROP_MEMBERSHIP: c_int = 21;
+pub(crate) const IPV6_ROUTER_ALERT: c_int = 22;
+pub(crate) const IPV6_MTU_DISCOVER: c_int = 23;
+pub(crate) const IPV6_MTU: c_int = 24;
+pub(crate) const IPV6_RECVERR: c_int = 25;
+pub(crate) const IPV6_V6ONLY: c_int = 26;
+pub(crate) const IPV6_JOIN_ANYCAST: c_int = 27;
+pub(crate) const IPV6_LEAVE_ANYCAST: c_int = 28;
+pub(crate) const IPV6_MULTICAST_ALL: c_int = 29;
+pub(crate) const IPV6_ROUTER_ALERT_ISOLATE: c_int = 30;
+pub(crate) const IPV6_IPSEC_POLICY: c_int = 34;
+pub(crate) const IPV6_XFRM_POLICY: c_int = 35;
+pub(crate) const IPV6_HDRINCL: c_int = 36;
+pub(crate) const IPV6_RECVPKTINFO: c_int = 49;
+pub(crate) const IPV6_PKTINFO: c_int = 50;
+pub(crate) const IPV6_RECVHOPLIMIT: c_int = 51;
+pub(crate) const IPV6_HOPLIMIT: c_int = 52;
+pub(crate) const IPV6_RECVHOPOPTS: c_int = 53;
+pub(crate) const IPV6_HOPOPTS: c_int = 54;
+pub(crate) const IPV6_RTHDRDSTOPTS: c_int = 55;
+pub(crate) const IPV6_RECVRTHDR: c_int = 56;
+pub(crate) const IPV6_RTHDR: c_int = 57;
+pub(crate) const IPV6_RECVDSTOPTS: c_int = 58;
+pub(crate) const IPV6_DSTOPTS: c_int = 59;
+pub(crate) const IPV6_RECVPATHMTU: c_int = 60;
+pub(crate) const IPV6_PATHMTU: c_int = 61;
+pub(crate) const IPV6_DONTFRAG: c_int = 62;
+pub(crate) const IPV6_RECVTCLASS: c_int = 66;
+pub(crate) const IPV6_TCLASS: c_int = 67;
+pub(crate) const IPV6_AUTOFLOWLABEL: c_int = 70;
+pub(crate) const IPV6_ADDR_PREFERENCES: c_int = 72;
+pub(crate) const IPV6_MINHOPCOUNT: c_int = 73;
+pub(crate) const IPV6_ORIGDSTADDR: c_int = 74;
+pub(crate) const IPV6_TRANSPARENT: c_int = 75;
+pub(crate) const IPV6_UNICAST_IF: c_int = 76;
+pub(crate) const IPV6_RECVFRAGSIZE: c_int = 77;
+pub(crate) const IPV6_FREEBIND: c_int = 78;
+
+pub(crate) const TCP_NODELAY: c_int = 1;
+pub(crate) const TCP_MAXSEG: c_int = 2;
+pub(crate) const TCP_CORK: c_int = 3;
+pub(crate) const TCP_KEEPIDLE: c_int = 4;
+pub(crate) const TCP_KEEPINTVL: c_int = 5;
+pub(crate) const TCP_KEEPCNT: c_int = 6;
+pub(crate) const TCP_SYNCNT: c_int = 7;
+pub(crate) const TCP_LINGER2: c_int = 8;
+pub(crate) const TCP_DEFER_ACCEPT: c_int = 9;
+pub(crate) const TCP_WINDOW_CLAMP: c_int = 10;
+pub(crate) const TCP_INFO: c_int = 11;
+pub(crate) const TCP_QUICKACK: c_int = 12;
+pub(crate) const TCP_CONGESTION: c_int = 13;
+pub(crate) const TCP_MD5SIG: c_int = 14;
+pub(crate) const TCP_THIN_LINEAR_TIMEOUTS: c_int = 16;
+pub(crate) const TCP_THIN_DUPACK: c_int = 17;
+pub(crate) const TCP_USER_TIMEOUT: c_int = 18;
+pub(crate) const TCP_REPAIR: c_int = 19;
+pub(crate) const TCP_REPAIR_QUEUE: c_int = 20;
+pub(crate) const TCP_QUEUE_SEQ: c_int = 21;
+pub(crate) const TCP_REPAIR_OPTIONS: c_int = 22;
+pub(crate) const TCP_FASTOPEN: c_int = 23;
+pub(crate) const TCP_TIMESTAMP: c_int = 24;
+pub(crate) const TCP_NOTSENT_LOWAT: c_int = 25;
+pub(crate) const TCP_CC_INFO: c_int = 26;
+pub(crate) const TCP_SAVE_SYN: c_int = 27;
+pub(crate) const TCP_SAVED_SYN: c_int = 28;
+pub(crate) const TCP_REPAIR_WINDOW: c_int = 29;
+pub(crate) const TCP_FASTOPEN_CONNECT: c_int = 30;
+pub(crate) const TCP_ULP: c_int = 31;
+pub(crate) const TCP_MD5SIG_EXT: c_int = 32;
+pub(crate) const TCP_FASTOPEN_KEY: c_int = 33;
+pub(crate) const TCP_FASTOPEN_NO_COOKIE: c_int = 34;
+pub(crate) const TCP_ZEROCOPY_RECEIVE: c_int = 35;
+pub(crate) const TCP_INQ: c_int = 36;
+
+pub(crate) const EAI_NONAME: c_int = -2;
+pub(crate) const EAI_SYSTEM: c_int = -11;
+
 #[repr(C)]
 pub(crate) struct Dirent64 {
     pub(crate) d_ino: u64,
@@ -66,16 +236,52 @@ pub(crate) struct Dirent64 {
 
 pub(crate) type SockLen = u32;
 
-/* FIXME: implement getsockopt, setsockopt, getaddrinfo, and freeaddrinfo
 #[repr(C)]
 pub(crate) struct Addrinfo {
-    ai_flags: c_int,
-    ai_family: c_int,
-    ai_socktype: c_int,
-    ai_protocol: c_int,
-    ai_addrlen: SockLen,
-    ai_addr: *mut rsix::net::SocketAddrStorage,
-    ai_canonname: *mut i8,
-    ai_next: *mut Addrinfo,
+    pub(crate) ai_flags: c_int,
+    pub(crate) ai_family: c_int,
+    pub(crate) ai_socktype: c_int,
+    pub(crate) ai_protocol: c_int,
+    pub(crate) ai_addrlen: SockLen,
+    pub(crate) ai_addr: *mut rsix::net::SocketAddrStorage,
+    pub(crate) ai_canonname: *mut i8,
+    pub(crate) ai_next: *mut Addrinfo,
 }
-*/
+
+#[repr(C)]
+pub(crate) struct Linger {
+    pub(crate) l_onoff: c_int,
+    pub(crate) l_linger: c_int,
+}
+
+#[repr(C)]
+pub(crate) struct Ipv4Addr {
+    pub(crate) s_addr: u32,
+}
+
+#[repr(C)]
+#[repr(align(4))]
+pub(crate) struct Ipv6Addr {
+    pub(crate) u6_addr8: [u8; 16usize],
+}
+
+#[repr(C)]
+pub(crate) struct Ipv4Mreq {
+    pub(crate) imr_multiaddr: Ipv4Addr,
+    pub(crate) imr_interface: Ipv4Addr,
+}
+
+#[repr(C)]
+pub(crate) struct Ipv6Mreq {
+    pub(crate) ipv6mr_multiaddr: Ipv6Addr,
+    pub(crate) ipv6mr_interface: c_int,
+}
+
+#[repr(C)]
+pub(crate) struct Timeval {
+    pub(crate) tv_sec: Time,
+    pub(crate) tv_usec: Suseconds,
+}
+
+pub(crate) type Time = c_long;
+pub(crate) type Suseconds = c_long;

--- a/c-scape/src/data/mod.rs
+++ b/c-scape/src/data/mod.rs
@@ -1,4 +1,5 @@
 #![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
 #![cfg_attr(test, allow(non_snake_case))]
 
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
@@ -50,6 +51,29 @@ macro_rules! type_ {
     };
 }
 
+macro_rules! struct_ {
+    ($name:ident, $libc:ident, $($field:ident),*) => {
+        // Check the size and alignment.
+        type_!($name, $libc);
+
+        // Check that the fields match libc's fields.
+        #[cfg(test)]
+        paste::paste! {
+            #[allow(dead_code)]
+            const [< TEST_ $name >]: once_cell::sync::Lazy<()> = once_cell::sync::Lazy::new(|| {
+                #[allow(non_snake_case)]
+                let [< struct_ $name >]: $name = $name {
+                    $($field: 0 as _),*
+                };
+                #[allow(non_snake_case)]
+                let [< _libc_ $name >]: libc::$libc = libc::$libc {
+                    $($field: [< struct_ $name >].$field),*
+                };
+            });
+        }
+    };
+}
+
 constant!(F_SETFD);
 constant!(F_GETFL);
 constant!(F_DUPFD_CLOEXEC);
@@ -84,8 +108,171 @@ constant!(SIG_DFL);
 constant!(SHUT_RD);
 constant!(SHUT_WR);
 constant!(SHUT_RDWR);
+constant!(SOL_SOCKET);
+constant!(IPPROTO_IP);
+constant!(IPPROTO_IPV6);
+constant!(IPPROTO_TCP);
+constant!(SO_REUSEADDR);
+constant!(SO_BROADCAST);
+constant!(SO_PASSCRED);
+constant!(SO_DEBUG);
+constant!(SO_TYPE);
+constant!(SO_ERROR);
+constant!(SO_DONTROUTE);
+constant!(SO_SNDBUF);
+constant!(SO_RCVBUF);
+constant!(SO_KEEPALIVE);
+constant!(SO_OOBINLINE);
+constant!(SO_NO_CHECK);
+constant!(SO_PRIORITY);
+constant!(SO_LINGER);
+constant!(SO_BSDCOMPAT);
+constant!(SO_REUSEPORT);
+constant!(SO_RCVLOWAT);
+constant!(SO_SNDLOWAT);
+constant!(SO_PEERCRED);
+constant!(SO_ACCEPTCONN);
+constant!(SO_PEERSEC);
+constant!(SO_SNDBUFFORCE);
+constant!(SO_RCVBUFFORCE);
+constant!(SO_PROTOCOL);
+constant!(SO_DOMAIN);
+constant!(SO_SNDTIMEO);
+constant!(SO_RCVTIMEO);
+constant!(IP_TOS);
+constant!(IP_TTL);
+constant!(IP_HDRINCL);
+constant!(IP_OPTIONS);
+constant!(IP_ROUTER_ALERT);
+constant!(IP_RECVOPTS);
+constant!(IP_RETOPTS);
+constant!(IP_PKTINFO);
+constant!(IP_PKTOPTIONS);
+constant!(IP_MTU_DISCOVER);
+constant!(IP_RECVERR);
+constant!(IP_RECVTTL);
+constant!(IP_RECVTOS);
+constant!(IP_MTU);
+constant!(IP_FREEBIND);
+constant!(IP_IPSEC_POLICY);
+constant!(IP_XFRM_POLICY);
+constant!(IP_PASSSEC);
+constant!(IP_TRANSPARENT);
+constant!(IP_ORIGDSTADDR);
+constant!(IP_MINTTL);
+constant!(IP_NODEFRAG);
+constant!(IP_CHECKSUM);
+constant!(IP_BIND_ADDRESS_NO_PORT);
+constant!(IP_RECVFRAGSIZE);
+constant!(IP_MULTICAST_IF);
+constant!(IP_MULTICAST_TTL);
+constant!(IP_MULTICAST_LOOP);
+constant!(IP_ADD_MEMBERSHIP);
+constant!(IP_DROP_MEMBERSHIP);
+constant!(IP_UNBLOCK_SOURCE);
+constant!(IP_BLOCK_SOURCE);
+constant!(IP_ADD_SOURCE_MEMBERSHIP);
+constant!(IP_DROP_SOURCE_MEMBERSHIP);
+constant!(IP_MSFILTER);
+constant!(IP_MULTICAST_ALL);
+constant!(IP_UNICAST_IF);
+constant!(IPV6_ADDRFORM);
+constant!(IPV6_2292PKTINFO);
+constant!(IPV6_2292HOPOPTS);
+constant!(IPV6_2292DSTOPTS);
+constant!(IPV6_2292RTHDR);
+constant!(IPV6_2292PKTOPTIONS);
+constant!(IPV6_CHECKSUM);
+constant!(IPV6_2292HOPLIMIT);
+constant!(IPV6_NEXTHOP);
+constant!(IPV6_AUTHHDR);
+constant!(IPV6_UNICAST_HOPS);
+constant!(IPV6_MULTICAST_IF);
+constant!(IPV6_MULTICAST_HOPS);
+constant!(IPV6_MULTICAST_LOOP);
+constant!(IPV6_ADD_MEMBERSHIP);
+constant!(IPV6_DROP_MEMBERSHIP);
+constant!(IPV6_ROUTER_ALERT);
+constant!(IPV6_MTU_DISCOVER);
+constant!(IPV6_MTU);
+constant!(IPV6_RECVERR);
+constant!(IPV6_V6ONLY);
+constant!(IPV6_JOIN_ANYCAST);
+constant!(IPV6_LEAVE_ANYCAST);
+constant!(IPV6_MULTICAST_ALL);
+constant!(IPV6_ROUTER_ALERT_ISOLATE);
+constant!(IPV6_IPSEC_POLICY);
+constant!(IPV6_XFRM_POLICY);
+constant!(IPV6_HDRINCL);
+constant!(IPV6_RECVPKTINFO);
+constant!(IPV6_PKTINFO);
+constant!(IPV6_RECVHOPLIMIT);
+constant!(IPV6_HOPLIMIT);
+constant!(IPV6_RECVHOPOPTS);
+constant!(IPV6_HOPOPTS);
+constant!(IPV6_RTHDRDSTOPTS);
+constant!(IPV6_RECVRTHDR);
+constant!(IPV6_RTHDR);
+constant!(IPV6_RECVDSTOPTS);
+constant!(IPV6_DSTOPTS);
+constant!(IPV6_RECVPATHMTU);
+constant!(IPV6_PATHMTU);
+constant!(IPV6_DONTFRAG);
+constant!(IPV6_RECVTCLASS);
+constant!(IPV6_TCLASS);
+constant!(IPV6_AUTOFLOWLABEL);
+constant!(IPV6_ADDR_PREFERENCES);
+constant!(IPV6_MINHOPCOUNT);
+constant!(IPV6_ORIGDSTADDR);
+constant!(IPV6_TRANSPARENT);
+constant!(IPV6_UNICAST_IF);
+constant!(IPV6_RECVFRAGSIZE);
+constant!(IPV6_FREEBIND);
+constant!(TCP_NODELAY);
+constant!(TCP_MAXSEG);
+constant!(TCP_CORK);
+constant!(TCP_KEEPIDLE);
+constant!(TCP_KEEPINTVL);
+constant!(TCP_KEEPCNT);
+constant!(TCP_SYNCNT);
+constant!(TCP_LINGER2);
+constant!(TCP_DEFER_ACCEPT);
+constant!(TCP_WINDOW_CLAMP);
+constant!(TCP_INFO);
+constant!(TCP_QUICKACK);
+constant!(TCP_CONGESTION);
+constant!(TCP_MD5SIG);
+constant!(TCP_THIN_LINEAR_TIMEOUTS);
+constant!(TCP_THIN_DUPACK);
+constant!(TCP_USER_TIMEOUT);
+constant!(TCP_REPAIR);
+constant!(TCP_REPAIR_QUEUE);
+constant!(TCP_QUEUE_SEQ);
+constant!(TCP_REPAIR_OPTIONS);
+constant!(TCP_FASTOPEN);
+constant!(TCP_TIMESTAMP);
+constant!(TCP_NOTSENT_LOWAT);
+constant!(TCP_CC_INFO);
+constant!(TCP_SAVE_SYN);
+constant!(TCP_SAVED_SYN);
+constant!(TCP_REPAIR_WINDOW);
+constant!(TCP_FASTOPEN_CONNECT);
+constant!(TCP_ULP);
+constant!(TCP_MD5SIG_EXT);
+constant!(TCP_FASTOPEN_KEY);
+constant!(TCP_FASTOPEN_NO_COOKIE);
+constant!(TCP_ZEROCOPY_RECEIVE);
+constant!(TCP_INQ);
+constant!(EAI_NONAME);
+constant!(EAI_SYSTEM);
 type_!(Dirent64, dirent64);
 type_!(SockLen, socklen_t);
-/* FIXME: implement getsockopt, setsockopt, getaddrinfo, and freeaddrinfo
- *type_!(Addrinfo, addrinfo);
- */
+type_!(Addrinfo, addrinfo);
+type_!(Linger, linger);
+type_!(Ipv4Addr, in_addr);
+type_!(Ipv6Addr, in6_addr);
+type_!(Ipv4Mreq, ip_mreq);
+type_!(Ipv6Mreq, ipv6_mreq);
+struct_!(Timeval, timeval, tv_sec, tv_usec);
+type_!(Time, time_t);
+type_!(Suseconds, suseconds_t);

--- a/examples/net-addr.rs
+++ b/examples/net-addr.rs
@@ -1,0 +1,268 @@
+//! The following is derived from Rust's
+//! library/std/src/net/addr/tests.rs at revision
+//! 497ee321af3b8496eaccd7af7b437f18bab81abf.
+
+mustang::can_compile_this!();
+
+mod net;
+
+use crate::net::test::{sa4, sa6, tsa};
+use std::net::*;
+
+//#[test]
+fn to_socket_addr_ipaddr_u16() {
+    let a = Ipv4Addr::new(77, 88, 21, 11);
+    let p = 12345;
+    let e = SocketAddr::V4(SocketAddrV4::new(a, p));
+    assert_eq!(Ok(vec![e]), tsa((a, p)));
+}
+
+//#[test]
+fn to_socket_addr_str_u16() {
+    let a = sa4(Ipv4Addr::new(77, 88, 21, 11), 24352);
+    assert_eq!(Ok(vec![a]), tsa(("77.88.21.11", 24352)));
+
+    let a = sa6(Ipv6Addr::new(0x2a02, 0x6b8, 0, 1, 0, 0, 0, 1), 53);
+    assert_eq!(Ok(vec![a]), tsa(("2a02:6b8:0:1::1", 53)));
+
+    let a = sa4(Ipv4Addr::new(127, 0, 0, 1), 23924);
+    #[cfg(not(target_env = "sgx"))]
+    assert!(tsa(("localhost", 23924)).unwrap().contains(&a));
+    #[cfg(target_env = "sgx")]
+    let _ = a;
+}
+
+//#[test]
+fn to_socket_addr_str() {
+    let a = sa4(Ipv4Addr::new(77, 88, 21, 11), 24352);
+    assert_eq!(Ok(vec![a]), tsa("77.88.21.11:24352"));
+
+    let a = sa6(Ipv6Addr::new(0x2a02, 0x6b8, 0, 1, 0, 0, 0, 1), 53);
+    assert_eq!(Ok(vec![a]), tsa("[2a02:6b8:0:1::1]:53"));
+
+    let a = sa4(Ipv4Addr::new(127, 0, 0, 1), 23924);
+    #[cfg(not(target_env = "sgx"))]
+    assert!(tsa("localhost:23924").unwrap().contains(&a));
+    #[cfg(target_env = "sgx")]
+    let _ = a;
+}
+
+//#[test]
+fn to_socket_addr_string() {
+    let a = sa4(Ipv4Addr::new(77, 88, 21, 11), 24352);
+    assert_eq!(Ok(vec![a]), tsa(&*format!("{}:{}", "77.88.21.11", "24352")));
+    assert_eq!(Ok(vec![a]), tsa(&format!("{}:{}", "77.88.21.11", "24352")));
+    assert_eq!(Ok(vec![a]), tsa(format!("{}:{}", "77.88.21.11", "24352")));
+
+    let s = format!("{}:{}", "77.88.21.11", "24352");
+    assert_eq!(Ok(vec![a]), tsa(s));
+    // s has been moved into the tsa call
+}
+
+//#[test]
+fn bind_udp_socket_bad() {
+    // rust-lang/rust#53957: This is a regression test for a parsing problem
+    // discovered as part of issue rust-lang/rust#23076, where we were
+    // incorrectly parsing invalid input and then that would result in a
+    // successful `UdpSocket` binding when we would expect failure.
+    //
+    // At one time, this test was written as a call to `tsa` with
+    // INPUT_23076. However, that structure yields an unreliable test,
+    // because it ends up passing junk input to the DNS server, and some DNS
+    // servers will respond with `Ok` to such input, with the ip address of
+    // the DNS server itself.
+    //
+    // This form of the test is more robust: even when the DNS server
+    // returns its own address, it is still an error to bind a UDP socket to
+    // a non-local address, and so we still get an error here in that case.
+
+    const INPUT_23076: &str = "1200::AB00:1234::2552:7777:1313:34300";
+
+    assert!(std::net::UdpSocket::bind(INPUT_23076).is_err())
+}
+
+//#[test]
+fn set_ip() {
+    fn ip4(low: u8) -> Ipv4Addr {
+        Ipv4Addr::new(77, 88, 21, low)
+    }
+    fn ip6(low: u16) -> Ipv6Addr {
+        Ipv6Addr::new(0x2a02, 0x6b8, 0, 1, 0, 0, 0, low)
+    }
+
+    let mut v4 = SocketAddrV4::new(ip4(11), 80);
+    assert_eq!(v4.ip(), &ip4(11));
+    v4.set_ip(ip4(12));
+    assert_eq!(v4.ip(), &ip4(12));
+
+    let mut addr = SocketAddr::V4(v4);
+    assert_eq!(addr.ip(), IpAddr::V4(ip4(12)));
+    addr.set_ip(IpAddr::V4(ip4(13)));
+    assert_eq!(addr.ip(), IpAddr::V4(ip4(13)));
+    addr.set_ip(IpAddr::V6(ip6(14)));
+    assert_eq!(addr.ip(), IpAddr::V6(ip6(14)));
+
+    let mut v6 = SocketAddrV6::new(ip6(1), 80, 0, 0);
+    assert_eq!(v6.ip(), &ip6(1));
+    v6.set_ip(ip6(2));
+    assert_eq!(v6.ip(), &ip6(2));
+
+    let mut addr = SocketAddr::V6(v6);
+    assert_eq!(addr.ip(), IpAddr::V6(ip6(2)));
+    addr.set_ip(IpAddr::V6(ip6(3)));
+    assert_eq!(addr.ip(), IpAddr::V6(ip6(3)));
+    addr.set_ip(IpAddr::V4(ip4(4)));
+    assert_eq!(addr.ip(), IpAddr::V4(ip4(4)));
+}
+
+//#[test]
+fn set_port() {
+    let mut v4 = SocketAddrV4::new(Ipv4Addr::new(77, 88, 21, 11), 80);
+    assert_eq!(v4.port(), 80);
+    v4.set_port(443);
+    assert_eq!(v4.port(), 443);
+
+    let mut addr = SocketAddr::V4(v4);
+    assert_eq!(addr.port(), 443);
+    addr.set_port(8080);
+    assert_eq!(addr.port(), 8080);
+
+    let mut v6 = SocketAddrV6::new(Ipv6Addr::new(0x2a02, 0x6b8, 0, 1, 0, 0, 0, 1), 80, 0, 0);
+    assert_eq!(v6.port(), 80);
+    v6.set_port(443);
+    assert_eq!(v6.port(), 443);
+
+    let mut addr = SocketAddr::V6(v6);
+    assert_eq!(addr.port(), 443);
+    addr.set_port(8080);
+    assert_eq!(addr.port(), 8080);
+}
+
+//#[test]
+fn set_flowinfo() {
+    let mut v6 = SocketAddrV6::new(Ipv6Addr::new(0x2a02, 0x6b8, 0, 1, 0, 0, 0, 1), 80, 10, 0);
+    assert_eq!(v6.flowinfo(), 10);
+    v6.set_flowinfo(20);
+    assert_eq!(v6.flowinfo(), 20);
+}
+
+//#[test]
+fn set_scope_id() {
+    let mut v6 = SocketAddrV6::new(Ipv6Addr::new(0x2a02, 0x6b8, 0, 1, 0, 0, 0, 1), 80, 0, 10);
+    assert_eq!(v6.scope_id(), 10);
+    v6.set_scope_id(20);
+    assert_eq!(v6.scope_id(), 20);
+}
+
+//#[test]
+fn is_v4() {
+    let v4 = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(77, 88, 21, 11), 80));
+    assert!(v4.is_ipv4());
+    assert!(!v4.is_ipv6());
+}
+
+//#[test]
+fn is_v6() {
+    let v6 = SocketAddr::V6(SocketAddrV6::new(
+        Ipv6Addr::new(0x2a02, 0x6b8, 0, 1, 0, 0, 0, 1),
+        80,
+        10,
+        0,
+    ));
+    assert!(!v6.is_ipv4());
+    assert!(v6.is_ipv6());
+}
+
+//#[test]
+fn socket_v4_to_str() {
+    let socket = SocketAddrV4::new(Ipv4Addr::new(192, 168, 0, 1), 8080);
+
+    assert_eq!(format!("{}", socket), "192.168.0.1:8080");
+    assert_eq!(format!("{:<20}", socket), "192.168.0.1:8080    ");
+    assert_eq!(format!("{:>20}", socket), "    192.168.0.1:8080");
+    assert_eq!(format!("{:^20}", socket), "  192.168.0.1:8080  ");
+    assert_eq!(format!("{:.10}", socket), "192.168.0.");
+}
+
+//#[test]
+fn socket_v6_to_str() {
+    let mut socket = SocketAddrV6::new(Ipv6Addr::new(0x2a02, 0x6b8, 0, 1, 0, 0, 0, 1), 53, 0, 0);
+
+    assert_eq!(format!("{}", socket), "[2a02:6b8:0:1::1]:53");
+    assert_eq!(format!("{:<24}", socket), "[2a02:6b8:0:1::1]:53    ");
+    assert_eq!(format!("{:>24}", socket), "    [2a02:6b8:0:1::1]:53");
+    assert_eq!(format!("{:^24}", socket), "  [2a02:6b8:0:1::1]:53  ");
+    assert_eq!(format!("{:.15}", socket), "[2a02:6b8:0:1::");
+
+    socket.set_scope_id(5);
+
+    assert_eq!(format!("{}", socket), "[2a02:6b8:0:1::1%5]:53");
+    assert_eq!(format!("{:<24}", socket), "[2a02:6b8:0:1::1%5]:53  ");
+    assert_eq!(format!("{:>24}", socket), "  [2a02:6b8:0:1::1%5]:53");
+    assert_eq!(format!("{:^24}", socket), " [2a02:6b8:0:1::1%5]:53 ");
+    assert_eq!(format!("{:.18}", socket), "[2a02:6b8:0:1::1%5");
+}
+
+//#[test]
+fn compare() {
+    let v4_1 = "224.120.45.1:23456".parse::<SocketAddrV4>().unwrap();
+    let v4_2 = "224.210.103.5:12345".parse::<SocketAddrV4>().unwrap();
+    let v4_3 = "224.210.103.5:23456".parse::<SocketAddrV4>().unwrap();
+    let v6_1 = "[2001:db8:f00::1002]:23456"
+        .parse::<SocketAddrV6>()
+        .unwrap();
+    let v6_2 = "[2001:db8:f00::2001]:12345"
+        .parse::<SocketAddrV6>()
+        .unwrap();
+    let v6_3 = "[2001:db8:f00::2001]:23456"
+        .parse::<SocketAddrV6>()
+        .unwrap();
+
+    // equality
+    assert_eq!(v4_1, v4_1);
+    assert_eq!(v6_1, v6_1);
+    assert_eq!(SocketAddr::V4(v4_1), SocketAddr::V4(v4_1));
+    assert_eq!(SocketAddr::V6(v6_1), SocketAddr::V6(v6_1));
+    assert!(v4_1 != v4_2);
+    assert!(v6_1 != v6_2);
+
+    // compare different addresses
+    assert!(v4_1 < v4_2);
+    assert!(v6_1 < v6_2);
+    assert!(v4_2 > v4_1);
+    assert!(v6_2 > v6_1);
+
+    // compare the same address with different ports
+    assert!(v4_2 < v4_3);
+    assert!(v6_2 < v6_3);
+    assert!(v4_3 > v4_2);
+    assert!(v6_3 > v6_2);
+
+    // compare different addresses with the same port
+    assert!(v4_1 < v4_3);
+    assert!(v6_1 < v6_3);
+    assert!(v4_3 > v4_1);
+    assert!(v6_3 > v6_1);
+
+    // compare with an inferred right-hand side
+    assert_eq!(v4_1, "224.120.45.1:23456".parse().unwrap());
+    assert_eq!(v6_1, "[2001:db8:f00::1002]:23456".parse().unwrap());
+    assert_eq!(SocketAddr::V4(v4_1), "224.120.45.1:23456".parse().unwrap());
+}
+
+fn main() {
+    to_socket_addr_ipaddr_u16();
+    to_socket_addr_str_u16();
+    to_socket_addr_str();
+    to_socket_addr_string();
+    bind_udp_socket_bad();
+    set_ip();
+    set_port();
+    set_flowinfo();
+    set_scope_id();
+    is_v4();
+    is_v6();
+    socket_v4_to_str();
+    socket_v6_to_str();
+    compare();
+}

--- a/examples/net-ip.rs
+++ b/examples/net-ip.rs
@@ -1,0 +1,1084 @@
+//! The following is derived from Rust's
+//! library/std/src/net/ip/tests.rs at revision
+//! 497ee321af3b8496eaccd7af7b437f18bab81abf.
+
+#![feature(ip)]
+#![feature(const_ip)]
+#![feature(const_ipv4)]
+#![feature(const_ipv6)]
+
+mustang::can_compile_this!();
+
+mod net;
+
+use crate::net::test::{sa4, sa6, tsa};
+use std::net::*;
+use std::str::FromStr;
+
+//#[test]
+fn test_from_str_ipv4() {
+    assert_eq!(Ok(Ipv4Addr::new(127, 0, 0, 1)), "127.0.0.1".parse());
+    assert_eq!(
+        Ok(Ipv4Addr::new(255, 255, 255, 255)),
+        "255.255.255.255".parse()
+    );
+    assert_eq!(Ok(Ipv4Addr::new(0, 0, 0, 0)), "0.0.0.0".parse());
+
+    // out of range
+    let none: Option<Ipv4Addr> = "256.0.0.1".parse().ok();
+    assert_eq!(None, none);
+    // too short
+    let none: Option<Ipv4Addr> = "255.0.0".parse().ok();
+    assert_eq!(None, none);
+    // too long
+    let none: Option<Ipv4Addr> = "255.0.0.1.2".parse().ok();
+    assert_eq!(None, none);
+    // no number between dots
+    let none: Option<Ipv4Addr> = "255.0..1".parse().ok();
+    assert_eq!(None, none);
+}
+
+//#[test]
+fn test_from_str_ipv6() {
+    assert_eq!(
+        Ok(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
+        "0:0:0:0:0:0:0:0".parse()
+    );
+    assert_eq!(
+        Ok(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+        "0:0:0:0:0:0:0:1".parse()
+    );
+
+    assert_eq!(Ok(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), "::1".parse());
+    assert_eq!(Ok(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)), "::".parse());
+
+    assert_eq!(
+        Ok(Ipv6Addr::new(0x2a02, 0x6b8, 0, 0, 0, 0, 0x11, 0x11)),
+        "2a02:6b8::11:11".parse()
+    );
+
+    // too long group
+    let none: Option<Ipv6Addr> = "::00000".parse().ok();
+    assert_eq!(None, none);
+    // too short
+    let none: Option<Ipv6Addr> = "1:2:3:4:5:6:7".parse().ok();
+    assert_eq!(None, none);
+    // too long
+    let none: Option<Ipv6Addr> = "1:2:3:4:5:6:7:8:9".parse().ok();
+    assert_eq!(None, none);
+    // triple colon
+    let none: Option<Ipv6Addr> = "1:2:::6:7:8".parse().ok();
+    assert_eq!(None, none);
+    // two double colons
+    let none: Option<Ipv6Addr> = "1:2::6::8".parse().ok();
+    assert_eq!(None, none);
+    // `::` indicating zero groups of zeros
+    let none: Option<Ipv6Addr> = "1:2:3:4::5:6:7:8".parse().ok();
+    assert_eq!(None, none);
+}
+
+//#[test]
+fn test_from_str_ipv4_in_ipv6() {
+    assert_eq!(
+        Ok(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 49152, 545)),
+        "::192.0.2.33".parse()
+    );
+    assert_eq!(
+        Ok(Ipv6Addr::new(0, 0, 0, 0, 0, 0xFFFF, 49152, 545)),
+        "::FFFF:192.0.2.33".parse()
+    );
+    assert_eq!(
+        Ok(Ipv6Addr::new(0x64, 0xff9b, 0, 0, 0, 0, 49152, 545)),
+        "64:ff9b::192.0.2.33".parse()
+    );
+    assert_eq!(
+        Ok(Ipv6Addr::new(
+            0x2001, 0xdb8, 0x122, 0xc000, 0x2, 0x2100, 49152, 545
+        )),
+        "2001:db8:122:c000:2:2100:192.0.2.33".parse()
+    );
+
+    // colon after v4
+    let none: Option<Ipv4Addr> = "::127.0.0.1:".parse().ok();
+    assert_eq!(None, none);
+    // not enough groups
+    let none: Option<Ipv6Addr> = "1.2.3.4.5:127.0.0.1".parse().ok();
+    assert_eq!(None, none);
+    // too many groups
+    let none: Option<Ipv6Addr> = "1.2.3.4.5:6:7:127.0.0.1".parse().ok();
+    assert_eq!(None, none);
+}
+
+//#[test]
+fn test_from_str_socket_addr() {
+    assert_eq!(
+        Ok(sa4(Ipv4Addr::new(77, 88, 21, 11), 80)),
+        "77.88.21.11:80".parse()
+    );
+    assert_eq!(
+        Ok(SocketAddrV4::new(Ipv4Addr::new(77, 88, 21, 11), 80)),
+        "77.88.21.11:80".parse()
+    );
+    assert_eq!(
+        Ok(sa6(Ipv6Addr::new(0x2a02, 0x6b8, 0, 1, 0, 0, 0, 1), 53)),
+        "[2a02:6b8:0:1::1]:53".parse()
+    );
+    assert_eq!(
+        Ok(SocketAddrV6::new(
+            Ipv6Addr::new(0x2a02, 0x6b8, 0, 1, 0, 0, 0, 1),
+            53,
+            0,
+            0
+        )),
+        "[2a02:6b8:0:1::1]:53".parse()
+    );
+    assert_eq!(
+        Ok(sa6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0x7F00, 1), 22)),
+        "[::127.0.0.1]:22".parse()
+    );
+    assert_eq!(
+        Ok(SocketAddrV6::new(
+            Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0x7F00, 1),
+            22,
+            0,
+            0
+        )),
+        "[::127.0.0.1]:22".parse()
+    );
+
+    // without port
+    let none: Option<SocketAddr> = "127.0.0.1".parse().ok();
+    assert_eq!(None, none);
+    // without port
+    let none: Option<SocketAddr> = "127.0.0.1:".parse().ok();
+    assert_eq!(None, none);
+    // wrong brackets around v4
+    let none: Option<SocketAddr> = "[127.0.0.1]:22".parse().ok();
+    assert_eq!(None, none);
+    // port out of range
+    let none: Option<SocketAddr> = "127.0.0.1:123456".parse().ok();
+    assert_eq!(None, none);
+}
+
+//#[test]
+fn ipv4_addr_to_string() {
+    assert_eq!(Ipv4Addr::new(127, 0, 0, 1).to_string(), "127.0.0.1");
+    // Short address
+    assert_eq!(Ipv4Addr::new(1, 1, 1, 1).to_string(), "1.1.1.1");
+    // Long address
+    assert_eq!(
+        Ipv4Addr::new(127, 127, 127, 127).to_string(),
+        "127.127.127.127"
+    );
+
+    // Test padding
+    assert_eq!(
+        &format!("{:16}", Ipv4Addr::new(1, 1, 1, 1)),
+        "1.1.1.1         "
+    );
+    assert_eq!(
+        &format!("{:>16}", Ipv4Addr::new(1, 1, 1, 1)),
+        "         1.1.1.1"
+    );
+}
+
+//#[test]
+fn ipv6_addr_to_string() {
+    // ipv4-mapped address
+    let a1 = Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc000, 0x280);
+    assert_eq!(a1.to_string(), "::ffff:192.0.2.128");
+
+    // ipv4-compatible address
+    let a1 = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0xc000, 0x280);
+    assert_eq!(a1.to_string(), "::192.0.2.128");
+
+    // v6 address with no zero segments
+    assert_eq!(
+        Ipv6Addr::new(8, 9, 10, 11, 12, 13, 14, 15).to_string(),
+        "8:9:a:b:c:d:e:f"
+    );
+
+    // longest possible IPv6 length
+    assert_eq!(
+        Ipv6Addr::new(0x1111, 0x2222, 0x3333, 0x4444, 0x5555, 0x6666, 0x7777, 0x8888).to_string(),
+        "1111:2222:3333:4444:5555:6666:7777:8888"
+    );
+    // padding
+    assert_eq!(
+        &format!("{:20}", Ipv6Addr::new(1, 2, 3, 4, 5, 6, 7, 8)),
+        "1:2:3:4:5:6:7:8     "
+    );
+    assert_eq!(
+        &format!("{:>20}", Ipv6Addr::new(1, 2, 3, 4, 5, 6, 7, 8)),
+        "     1:2:3:4:5:6:7:8"
+    );
+
+    // reduce a single run of zeros
+    assert_eq!(
+        "ae::ffff:102:304",
+        Ipv6Addr::new(0xae, 0, 0, 0, 0, 0xffff, 0x0102, 0x0304).to_string()
+    );
+
+    // don't reduce just a single zero segment
+    assert_eq!(
+        "1:2:3:4:5:6:0:8",
+        Ipv6Addr::new(1, 2, 3, 4, 5, 6, 0, 8).to_string()
+    );
+
+    // 'any' address
+    assert_eq!("::", Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0).to_string());
+
+    // loopback address
+    assert_eq!("::1", Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1).to_string());
+
+    // ends in zeros
+    assert_eq!("1::", Ipv6Addr::new(1, 0, 0, 0, 0, 0, 0, 0).to_string());
+
+    // two runs of zeros, second one is longer
+    assert_eq!(
+        "1:0:0:4::8",
+        Ipv6Addr::new(1, 0, 0, 4, 0, 0, 0, 8).to_string()
+    );
+
+    // two runs of zeros, equal length
+    assert_eq!(
+        "1::4:5:0:0:8",
+        Ipv6Addr::new(1, 0, 0, 4, 5, 0, 0, 8).to_string()
+    );
+
+    // don't prefix `0x` to each segment in `dbg!`.
+    assert_eq!(
+        "1::4:5:0:0:8",
+        &format!("{:#?}", Ipv6Addr::new(1, 0, 0, 4, 5, 0, 0, 8))
+    );
+}
+
+//#[test]
+fn ipv4_to_ipv6() {
+    assert_eq!(
+        Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x1234, 0x5678),
+        Ipv4Addr::new(0x12, 0x34, 0x56, 0x78).to_ipv6_mapped()
+    );
+    assert_eq!(
+        Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0x1234, 0x5678),
+        Ipv4Addr::new(0x12, 0x34, 0x56, 0x78).to_ipv6_compatible()
+    );
+}
+
+//#[test]
+fn ipv6_to_ipv4_mapped() {
+    assert_eq!(
+        Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x1234, 0x5678).to_ipv4_mapped(),
+        Some(Ipv4Addr::new(0x12, 0x34, 0x56, 0x78))
+    );
+    assert_eq!(
+        Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0x1234, 0x5678).to_ipv4_mapped(),
+        None
+    );
+}
+
+//#[test]
+fn ipv6_to_ipv4() {
+    assert_eq!(
+        Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x1234, 0x5678).to_ipv4(),
+        Some(Ipv4Addr::new(0x12, 0x34, 0x56, 0x78))
+    );
+    assert_eq!(
+        Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0x1234, 0x5678).to_ipv4(),
+        Some(Ipv4Addr::new(0x12, 0x34, 0x56, 0x78))
+    );
+    assert_eq!(
+        Ipv6Addr::new(0, 0, 1, 0, 0, 0, 0x1234, 0x5678).to_ipv4(),
+        None
+    );
+}
+
+//#[test]
+fn ip_properties() {
+    macro_rules! ip {
+        ($s:expr) => {
+            IpAddr::from_str($s).unwrap()
+        };
+    }
+
+    macro_rules! check {
+        ($s:expr) => {
+            check!($s, 0);
+        };
+
+        ($s:expr, $mask:expr) => {{
+            let unspec: u8 = 1 << 0;
+            let loopback: u8 = 1 << 1;
+            let global: u8 = 1 << 2;
+            let multicast: u8 = 1 << 3;
+            let doc: u8 = 1 << 4;
+
+            if ($mask & unspec) == unspec {
+                assert!(ip!($s).is_unspecified());
+            } else {
+                assert!(!ip!($s).is_unspecified());
+            }
+
+            if ($mask & loopback) == loopback {
+                assert!(ip!($s).is_loopback());
+            } else {
+                assert!(!ip!($s).is_loopback());
+            }
+
+            if ($mask & global) == global {
+                assert!(ip!($s).is_global());
+            } else {
+                assert!(!ip!($s).is_global());
+            }
+
+            if ($mask & multicast) == multicast {
+                assert!(ip!($s).is_multicast());
+            } else {
+                assert!(!ip!($s).is_multicast());
+            }
+
+            if ($mask & doc) == doc {
+                assert!(ip!($s).is_documentation());
+            } else {
+                assert!(!ip!($s).is_documentation());
+            }
+        }};
+    }
+
+    let unspec: u8 = 1 << 0;
+    let loopback: u8 = 1 << 1;
+    let global: u8 = 1 << 2;
+    let multicast: u8 = 1 << 3;
+    let doc: u8 = 1 << 4;
+
+    check!("0.0.0.0", unspec);
+    check!("0.0.0.1");
+    check!("0.1.0.0");
+    check!("10.9.8.7");
+    check!("127.1.2.3", loopback);
+    check!("172.31.254.253");
+    check!("169.254.253.242");
+    check!("192.0.2.183", doc);
+    check!("192.1.2.183", global);
+    check!("192.168.254.253");
+    check!("198.51.100.0", doc);
+    check!("203.0.113.0", doc);
+    check!("203.2.113.0", global);
+    check!("224.0.0.0", global | multicast);
+    check!("239.255.255.255", global | multicast);
+    check!("255.255.255.255");
+    // make sure benchmarking addresses are not global
+    check!("198.18.0.0");
+    check!("198.18.54.2");
+    check!("198.19.255.255");
+    // make sure addresses reserved for protocol assignment are not global
+    check!("192.0.0.0");
+    check!("192.0.0.255");
+    check!("192.0.0.100");
+    // make sure reserved addresses are not global
+    check!("240.0.0.0");
+    check!("251.54.1.76");
+    check!("254.255.255.255");
+    // make sure shared addresses are not global
+    check!("100.64.0.0");
+    check!("100.127.255.255");
+    check!("100.100.100.0");
+
+    check!("::", unspec);
+    check!("::1", loopback);
+    check!("::0.0.0.2", global);
+    check!("1::", global);
+    check!("fc00::");
+    check!("fdff:ffff::");
+    check!("fe80:ffff::");
+    check!("febf:ffff::");
+    check!("fec0::", global);
+    check!("ff01::", multicast);
+    check!("ff02::", multicast);
+    check!("ff03::", multicast);
+    check!("ff04::", multicast);
+    check!("ff05::", multicast);
+    check!("ff08::", multicast);
+    check!("ff0e::", global | multicast);
+    check!("2001:db8:85a3::8a2e:370:7334", doc);
+    check!("102:304:506:708:90a:b0c:d0e:f10", global);
+}
+
+//#[test]
+fn ipv4_properties() {
+    macro_rules! ip {
+        ($s:expr) => {
+            Ipv4Addr::from_str($s).unwrap()
+        };
+    }
+
+    macro_rules! check {
+        ($s:expr) => {
+            check!($s, 0);
+        };
+
+        ($s:expr, $mask:expr) => {{
+            let unspec: u16 = 1 << 0;
+            let loopback: u16 = 1 << 1;
+            let private: u16 = 1 << 2;
+            let link_local: u16 = 1 << 3;
+            let global: u16 = 1 << 4;
+            let multicast: u16 = 1 << 5;
+            let broadcast: u16 = 1 << 6;
+            let documentation: u16 = 1 << 7;
+            let benchmarking: u16 = 1 << 8;
+            let reserved: u16 = 1 << 10;
+            let shared: u16 = 1 << 11;
+
+            if ($mask & unspec) == unspec {
+                assert!(ip!($s).is_unspecified());
+            } else {
+                assert!(!ip!($s).is_unspecified());
+            }
+
+            if ($mask & loopback) == loopback {
+                assert!(ip!($s).is_loopback());
+            } else {
+                assert!(!ip!($s).is_loopback());
+            }
+
+            if ($mask & private) == private {
+                assert!(ip!($s).is_private());
+            } else {
+                assert!(!ip!($s).is_private());
+            }
+
+            if ($mask & link_local) == link_local {
+                assert!(ip!($s).is_link_local());
+            } else {
+                assert!(!ip!($s).is_link_local());
+            }
+
+            if ($mask & global) == global {
+                assert!(ip!($s).is_global());
+            } else {
+                assert!(!ip!($s).is_global());
+            }
+
+            if ($mask & multicast) == multicast {
+                assert!(ip!($s).is_multicast());
+            } else {
+                assert!(!ip!($s).is_multicast());
+            }
+
+            if ($mask & broadcast) == broadcast {
+                assert!(ip!($s).is_broadcast());
+            } else {
+                assert!(!ip!($s).is_broadcast());
+            }
+
+            if ($mask & documentation) == documentation {
+                assert!(ip!($s).is_documentation());
+            } else {
+                assert!(!ip!($s).is_documentation());
+            }
+
+            if ($mask & benchmarking) == benchmarking {
+                assert!(ip!($s).is_benchmarking());
+            } else {
+                assert!(!ip!($s).is_benchmarking());
+            }
+
+            if ($mask & reserved) == reserved {
+                assert!(ip!($s).is_reserved());
+            } else {
+                assert!(!ip!($s).is_reserved());
+            }
+
+            if ($mask & shared) == shared {
+                assert!(ip!($s).is_shared());
+            } else {
+                assert!(!ip!($s).is_shared());
+            }
+        }};
+    }
+
+    let unspec: u16 = 1 << 0;
+    let loopback: u16 = 1 << 1;
+    let private: u16 = 1 << 2;
+    let link_local: u16 = 1 << 3;
+    let global: u16 = 1 << 4;
+    let multicast: u16 = 1 << 5;
+    let broadcast: u16 = 1 << 6;
+    let documentation: u16 = 1 << 7;
+    let benchmarking: u16 = 1 << 8;
+    let reserved: u16 = 1 << 10;
+    let shared: u16 = 1 << 11;
+
+    check!("0.0.0.0", unspec);
+    check!("0.0.0.1");
+    check!("0.1.0.0");
+    check!("10.9.8.7", private);
+    check!("127.1.2.3", loopback);
+    check!("172.31.254.253", private);
+    check!("169.254.253.242", link_local);
+    check!("192.0.2.183", documentation);
+    check!("192.1.2.183", global);
+    check!("192.168.254.253", private);
+    check!("198.51.100.0", documentation);
+    check!("203.0.113.0", documentation);
+    check!("203.2.113.0", global);
+    check!("224.0.0.0", global | multicast);
+    check!("239.255.255.255", global | multicast);
+    check!("255.255.255.255", broadcast);
+    check!("198.18.0.0", benchmarking);
+    check!("198.18.54.2", benchmarking);
+    check!("198.19.255.255", benchmarking);
+    check!("192.0.0.0");
+    check!("192.0.0.255");
+    check!("192.0.0.100");
+    check!("240.0.0.0", reserved);
+    check!("251.54.1.76", reserved);
+    check!("254.255.255.255", reserved);
+    check!("100.64.0.0", shared);
+    check!("100.127.255.255", shared);
+    check!("100.100.100.0", shared);
+}
+
+//#[test]
+fn ipv6_properties() {
+    macro_rules! ip {
+        ($s:expr) => {
+            Ipv6Addr::from_str($s).unwrap()
+        };
+    }
+
+    macro_rules! check {
+        ($s:expr, &[$($octet:expr),*], $mask:expr) => {
+            assert_eq!($s, ip!($s).to_string());
+            let octets = &[$($octet),*];
+            assert_eq!(&ip!($s).octets(), octets);
+            assert_eq!(Ipv6Addr::from(*octets), ip!($s));
+
+            let unspecified: u16 = 1 << 0;
+            let loopback: u16 = 1 << 1;
+            let unique_local: u16 = 1 << 2;
+            let global: u16 = 1 << 3;
+            let unicast_link_local: u16 = 1 << 4;
+            let unicast_global: u16 = 1 << 7;
+            let documentation: u16 = 1 << 8;
+            let multicast_interface_local: u16 = 1 << 9;
+            let multicast_link_local: u16 = 1 << 10;
+            let multicast_realm_local: u16 = 1 << 11;
+            let multicast_admin_local: u16 = 1 << 12;
+            let multicast_site_local: u16 = 1 << 13;
+            let multicast_organization_local: u16 = 1 << 14;
+            let multicast_global: u16 = 1 << 15;
+            let multicast: u16 = multicast_interface_local
+                | multicast_admin_local
+                | multicast_global
+                | multicast_link_local
+                | multicast_realm_local
+                | multicast_site_local
+                | multicast_organization_local;
+
+            if ($mask & unspecified) == unspecified {
+                assert!(ip!($s).is_unspecified());
+            } else {
+                assert!(!ip!($s).is_unspecified());
+            }
+            if ($mask & loopback) == loopback {
+                assert!(ip!($s).is_loopback());
+            } else {
+                assert!(!ip!($s).is_loopback());
+            }
+            if ($mask & unique_local) == unique_local {
+                assert!(ip!($s).is_unique_local());
+            } else {
+                assert!(!ip!($s).is_unique_local());
+            }
+            if ($mask & global) == global {
+                assert!(ip!($s).is_global());
+            } else {
+                assert!(!ip!($s).is_global());
+            }
+            if ($mask & unicast_link_local) == unicast_link_local {
+                assert!(ip!($s).is_unicast_link_local());
+            } else {
+                assert!(!ip!($s).is_unicast_link_local());
+            }
+            if ($mask & unicast_global) == unicast_global {
+                assert!(ip!($s).is_unicast_global());
+            } else {
+                assert!(!ip!($s).is_unicast_global());
+            }
+            if ($mask & documentation) == documentation {
+                assert!(ip!($s).is_documentation());
+            } else {
+                assert!(!ip!($s).is_documentation());
+            }
+            if ($mask & multicast) != 0 {
+                assert!(ip!($s).multicast_scope().is_some());
+                assert!(ip!($s).is_multicast());
+            } else {
+                assert!(ip!($s).multicast_scope().is_none());
+                assert!(!ip!($s).is_multicast());
+            }
+            if ($mask & multicast_interface_local) == multicast_interface_local {
+                assert_eq!(ip!($s).multicast_scope().unwrap(),
+                           Ipv6MulticastScope::InterfaceLocal);
+            }
+            if ($mask & multicast_link_local) == multicast_link_local {
+                assert_eq!(ip!($s).multicast_scope().unwrap(),
+                           Ipv6MulticastScope::LinkLocal);
+            }
+            if ($mask & multicast_realm_local) == multicast_realm_local {
+                assert_eq!(ip!($s).multicast_scope().unwrap(),
+                           Ipv6MulticastScope::RealmLocal);
+            }
+            if ($mask & multicast_admin_local) == multicast_admin_local {
+                assert_eq!(ip!($s).multicast_scope().unwrap(),
+                           Ipv6MulticastScope::AdminLocal);
+            }
+            if ($mask & multicast_site_local) == multicast_site_local {
+                assert_eq!(ip!($s).multicast_scope().unwrap(),
+                           Ipv6MulticastScope::SiteLocal);
+            }
+            if ($mask & multicast_organization_local) == multicast_organization_local {
+                assert_eq!(ip!($s).multicast_scope().unwrap(),
+                           Ipv6MulticastScope::OrganizationLocal);
+            }
+            if ($mask & multicast_global) == multicast_global {
+                assert_eq!(ip!($s).multicast_scope().unwrap(),
+                           Ipv6MulticastScope::Global);
+            }
+        }
+    }
+
+    let unspecified: u16 = 1 << 0;
+    let loopback: u16 = 1 << 1;
+    let unique_local: u16 = 1 << 2;
+    let global: u16 = 1 << 3;
+    let unicast_link_local: u16 = 1 << 4;
+    let unicast_global: u16 = 1 << 7;
+    let documentation: u16 = 1 << 8;
+    let multicast_interface_local: u16 = 1 << 9;
+    let multicast_link_local: u16 = 1 << 10;
+    let multicast_realm_local: u16 = 1 << 11;
+    let multicast_admin_local: u16 = 1 << 12;
+    let multicast_site_local: u16 = 1 << 13;
+    let multicast_organization_local: u16 = 1 << 14;
+    let multicast_global: u16 = 1 << 15;
+
+    check!(
+        "::",
+        &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        unspecified
+    );
+
+    check!(
+        "::1",
+        &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+        loopback
+    );
+
+    check!(
+        "::0.0.0.2",
+        &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2],
+        global | unicast_global
+    );
+
+    check!(
+        "1::",
+        &[0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        global | unicast_global
+    );
+
+    check!(
+        "fc00::",
+        &[0xfc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        unique_local
+    );
+
+    check!(
+        "fdff:ffff::",
+        &[0xfd, 0xff, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        unique_local
+    );
+
+    check!(
+        "fe80:ffff::",
+        &[0xfe, 0x80, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        unicast_link_local
+    );
+
+    check!(
+        "fe80::",
+        &[0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        unicast_link_local
+    );
+
+    check!(
+        "febf:ffff::",
+        &[0xfe, 0xbf, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        unicast_link_local
+    );
+
+    check!(
+        "febf::",
+        &[0xfe, 0xbf, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        unicast_link_local
+    );
+
+    check!(
+        "febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        &[
+            0xfe, 0xbf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff
+        ],
+        unicast_link_local
+    );
+
+    check!(
+        "fe80::ffff:ffff:ffff:ffff",
+        &[
+            0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff
+        ],
+        unicast_link_local
+    );
+
+    check!(
+        "fe80:0:0:1::",
+        &[0xfe, 0x80, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+        unicast_link_local
+    );
+
+    check!(
+        "fec0::",
+        &[0xfe, 0xc0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        unicast_global | global
+    );
+
+    check!(
+        "ff01::",
+        &[0xff, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        multicast_interface_local
+    );
+
+    check!(
+        "ff02::",
+        &[0xff, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        multicast_link_local
+    );
+
+    check!(
+        "ff03::",
+        &[0xff, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        multicast_realm_local
+    );
+
+    check!(
+        "ff04::",
+        &[0xff, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        multicast_admin_local
+    );
+
+    check!(
+        "ff05::",
+        &[0xff, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        multicast_site_local
+    );
+
+    check!(
+        "ff08::",
+        &[0xff, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        multicast_organization_local
+    );
+
+    check!(
+        "ff0e::",
+        &[0xff, 0xe, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        multicast_global | global
+    );
+
+    check!(
+        "2001:db8:85a3::8a2e:370:7334",
+        &[0x20, 1, 0xd, 0xb8, 0x85, 0xa3, 0, 0, 0, 0, 0x8a, 0x2e, 3, 0x70, 0x73, 0x34],
+        documentation
+    );
+
+    check!(
+        "102:304:506:708:90a:b0c:d0e:f10",
+        &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+        global | unicast_global
+    );
+}
+
+//#[test]
+fn to_socket_addr_socketaddr() {
+    let a = sa4(Ipv4Addr::new(77, 88, 21, 11), 12345);
+    assert_eq!(Ok(vec![a]), tsa(a));
+}
+
+//#[test]
+fn test_ipv4_to_int() {
+    let a = Ipv4Addr::new(0x11, 0x22, 0x33, 0x44);
+    assert_eq!(u32::from(a), 0x11223344);
+}
+
+//#[test]
+fn test_int_to_ipv4() {
+    let a = Ipv4Addr::new(0x11, 0x22, 0x33, 0x44);
+    assert_eq!(Ipv4Addr::from(0x11223344), a);
+}
+
+//#[test]
+fn test_ipv6_to_int() {
+    let a = Ipv6Addr::new(
+        0x1122, 0x3344, 0x5566, 0x7788, 0x99aa, 0xbbcc, 0xddee, 0xff11,
+    );
+    assert_eq!(u128::from(a), 0x112233445566778899aabbccddeeff11u128);
+}
+
+//#[test]
+fn test_int_to_ipv6() {
+    let a = Ipv6Addr::new(
+        0x1122, 0x3344, 0x5566, 0x7788, 0x99aa, 0xbbcc, 0xddee, 0xff11,
+    );
+    assert_eq!(Ipv6Addr::from(0x112233445566778899aabbccddeeff11u128), a);
+}
+
+//#[test]
+fn ipv4_from_constructors() {
+    assert_eq!(Ipv4Addr::LOCALHOST, Ipv4Addr::new(127, 0, 0, 1));
+    assert!(Ipv4Addr::LOCALHOST.is_loopback());
+    assert_eq!(Ipv4Addr::UNSPECIFIED, Ipv4Addr::new(0, 0, 0, 0));
+    assert!(Ipv4Addr::UNSPECIFIED.is_unspecified());
+    assert_eq!(Ipv4Addr::BROADCAST, Ipv4Addr::new(255, 255, 255, 255));
+    assert!(Ipv4Addr::BROADCAST.is_broadcast());
+}
+
+//#[test]
+fn ipv6_from_contructors() {
+    assert_eq!(Ipv6Addr::LOCALHOST, Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+    assert!(Ipv6Addr::LOCALHOST.is_loopback());
+    assert_eq!(Ipv6Addr::UNSPECIFIED, Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0));
+    assert!(Ipv6Addr::UNSPECIFIED.is_unspecified());
+}
+
+//#[test]
+fn ipv4_from_octets() {
+    assert_eq!(Ipv4Addr::from([127, 0, 0, 1]), Ipv4Addr::new(127, 0, 0, 1))
+}
+
+//#[test]
+fn ipv6_from_segments() {
+    let from_u16s = Ipv6Addr::from([
+        0x0011, 0x2233, 0x4455, 0x6677, 0x8899, 0xaabb, 0xccdd, 0xeeff,
+    ]);
+    let new = Ipv6Addr::new(
+        0x0011, 0x2233, 0x4455, 0x6677, 0x8899, 0xaabb, 0xccdd, 0xeeff,
+    );
+    assert_eq!(new, from_u16s);
+}
+
+//#[test]
+fn ipv6_from_octets() {
+    let from_u16s = Ipv6Addr::from([
+        0x0011, 0x2233, 0x4455, 0x6677, 0x8899, 0xaabb, 0xccdd, 0xeeff,
+    ]);
+    let from_u8s = Ipv6Addr::from([
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
+        0xff,
+    ]);
+    assert_eq!(from_u16s, from_u8s);
+}
+
+//#[test]
+fn cmp() {
+    let v41 = Ipv4Addr::new(100, 64, 3, 3);
+    let v42 = Ipv4Addr::new(192, 0, 2, 2);
+    let v61 = "2001:db8:f00::1002".parse::<Ipv6Addr>().unwrap();
+    let v62 = "2001:db8:f00::2001".parse::<Ipv6Addr>().unwrap();
+    assert!(v41 < v42);
+    assert!(v61 < v62);
+
+    assert_eq!(v41, IpAddr::V4(v41));
+    assert_eq!(v61, IpAddr::V6(v61));
+    assert!(v41 != IpAddr::V4(v42));
+    assert!(v61 != IpAddr::V6(v62));
+
+    assert!(v41 < IpAddr::V4(v42));
+    assert!(v61 < IpAddr::V6(v62));
+    assert!(IpAddr::V4(v41) < v42);
+    assert!(IpAddr::V6(v61) < v62);
+
+    assert!(v41 < IpAddr::V6(v61));
+    assert!(IpAddr::V4(v41) < v61);
+}
+
+//#[test]
+fn is_v4() {
+    let ip = IpAddr::V4(Ipv4Addr::new(100, 64, 3, 3));
+    assert!(ip.is_ipv4());
+    assert!(!ip.is_ipv6());
+}
+
+//#[test]
+fn is_v6() {
+    let ip = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x1234, 0x5678));
+    assert!(!ip.is_ipv4());
+    assert!(ip.is_ipv6());
+}
+
+//#[test]
+fn ipv4_const() {
+    // test that the methods of `Ipv4Addr` are usable in a const context
+
+    const IP_ADDRESS: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
+    assert_eq!(IP_ADDRESS, Ipv4Addr::LOCALHOST);
+
+    const OCTETS: [u8; 4] = IP_ADDRESS.octets();
+    assert_eq!(OCTETS, [127, 0, 0, 1]);
+
+    const IS_UNSPECIFIED: bool = IP_ADDRESS.is_unspecified();
+    assert!(!IS_UNSPECIFIED);
+
+    const IS_LOOPBACK: bool = IP_ADDRESS.is_loopback();
+    assert!(IS_LOOPBACK);
+
+    const IS_PRIVATE: bool = IP_ADDRESS.is_private();
+    assert!(!IS_PRIVATE);
+
+    const IS_LINK_LOCAL: bool = IP_ADDRESS.is_link_local();
+    assert!(!IS_LINK_LOCAL);
+
+    const IS_GLOBAL: bool = IP_ADDRESS.is_global();
+    assert!(!IS_GLOBAL);
+
+    const IS_SHARED: bool = IP_ADDRESS.is_shared();
+    assert!(!IS_SHARED);
+
+    const IS_BENCHMARKING: bool = IP_ADDRESS.is_benchmarking();
+    assert!(!IS_BENCHMARKING);
+
+    const IS_RESERVED: bool = IP_ADDRESS.is_reserved();
+    assert!(!IS_RESERVED);
+
+    const IS_MULTICAST: bool = IP_ADDRESS.is_multicast();
+    assert!(!IS_MULTICAST);
+
+    const IS_BROADCAST: bool = IP_ADDRESS.is_broadcast();
+    assert!(!IS_BROADCAST);
+
+    const IS_DOCUMENTATION: bool = IP_ADDRESS.is_documentation();
+    assert!(!IS_DOCUMENTATION);
+
+    const IP_V6_COMPATIBLE: Ipv6Addr = IP_ADDRESS.to_ipv6_compatible();
+    assert_eq!(
+        IP_V6_COMPATIBLE,
+        Ipv6Addr::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 127, 0, 0, 1])
+    );
+
+    const IP_V6_MAPPED: Ipv6Addr = IP_ADDRESS.to_ipv6_mapped();
+    assert_eq!(
+        IP_V6_MAPPED,
+        Ipv6Addr::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 0, 0, 1])
+    );
+}
+
+//#[test]
+fn ipv6_const() {
+    // test that the methods of `Ipv6Addr` are usable in a const context
+
+    const IP_ADDRESS: Ipv6Addr = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
+    assert_eq!(IP_ADDRESS, Ipv6Addr::LOCALHOST);
+
+    const SEGMENTS: [u16; 8] = IP_ADDRESS.segments();
+    assert_eq!(SEGMENTS, [0, 0, 0, 0, 0, 0, 0, 1]);
+
+    const OCTETS: [u8; 16] = IP_ADDRESS.octets();
+    assert_eq!(OCTETS, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+
+    const IS_UNSPECIFIED: bool = IP_ADDRESS.is_unspecified();
+    assert!(!IS_UNSPECIFIED);
+
+    const IS_LOOPBACK: bool = IP_ADDRESS.is_loopback();
+    assert!(IS_LOOPBACK);
+
+    const IS_GLOBAL: bool = IP_ADDRESS.is_global();
+    assert!(!IS_GLOBAL);
+
+    const IS_UNIQUE_LOCAL: bool = IP_ADDRESS.is_unique_local();
+    assert!(!IS_UNIQUE_LOCAL);
+
+    const IS_UNICAST_LINK_LOCAL: bool = IP_ADDRESS.is_unicast_link_local();
+    assert!(!IS_UNICAST_LINK_LOCAL);
+
+    const IS_DOCUMENTATION: bool = IP_ADDRESS.is_documentation();
+    assert!(!IS_DOCUMENTATION);
+
+    const IS_UNICAST_GLOBAL: bool = IP_ADDRESS.is_unicast_global();
+    assert!(!IS_UNICAST_GLOBAL);
+
+    const MULTICAST_SCOPE: Option<Ipv6MulticastScope> = IP_ADDRESS.multicast_scope();
+    assert_eq!(MULTICAST_SCOPE, None);
+
+    const IS_MULTICAST: bool = IP_ADDRESS.is_multicast();
+    assert!(!IS_MULTICAST);
+
+    const IP_V4: Option<Ipv4Addr> = IP_ADDRESS.to_ipv4();
+    assert_eq!(IP_V4.unwrap(), Ipv4Addr::new(0, 0, 0, 1));
+}
+
+//#[test]
+fn ip_const() {
+    // test that the methods of `IpAddr` are usable in a const context
+
+    const IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+    const IS_UNSPECIFIED: bool = IP_ADDRESS.is_unspecified();
+    assert!(!IS_UNSPECIFIED);
+
+    const IS_LOOPBACK: bool = IP_ADDRESS.is_loopback();
+    assert!(IS_LOOPBACK);
+
+    const IS_GLOBAL: bool = IP_ADDRESS.is_global();
+    assert!(!IS_GLOBAL);
+
+    const IS_MULTICAST: bool = IP_ADDRESS.is_multicast();
+    assert!(!IS_MULTICAST);
+
+    const IS_IP_V4: bool = IP_ADDRESS.is_ipv4();
+    assert!(IS_IP_V4);
+
+    const IS_IP_V6: bool = IP_ADDRESS.is_ipv6();
+    assert!(!IS_IP_V6);
+}
+
+fn main() {
+    test_from_str_ipv4();
+    test_from_str_ipv6();
+    test_from_str_ipv4_in_ipv6();
+    test_from_str_socket_addr();
+    ipv4_addr_to_string();
+    ipv6_addr_to_string();
+    ipv4_to_ipv6();
+    ipv6_to_ipv4_mapped();
+    ipv6_to_ipv4();
+    ip_properties();
+    ipv4_properties();
+    ipv6_properties();
+    to_socket_addr_socketaddr();
+    test_ipv4_to_int();
+    test_int_to_ipv4();
+    test_ipv6_to_int();
+    test_int_to_ipv6();
+    ipv4_from_constructors();
+    ipv6_from_contructors();
+    ipv4_from_octets();
+    ipv6_from_segments();
+    ipv6_from_octets();
+    cmp();
+    is_v4();
+    is_v6();
+    ipv4_const();
+    ipv6_const();
+    ip_const();
+}

--- a/examples/net-tcp.rs
+++ b/examples/net-tcp.rs
@@ -17,9 +17,9 @@ use std::fmt;
 use std::io::prelude::*;
 use std::io::{ErrorKind, IoSlice, IoSliceMut};
 use std::net::*;
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 use std::sync::mpsc::channel;
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -61,7 +61,7 @@ fn connect_error() {
     }
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn listen_localhost() {
     let socket_addr = next_test_ip4();
@@ -78,7 +78,7 @@ fn listen_localhost() {
     assert!(buf[0] == 144);
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn connect_loopback() {
     each_ip(&mut |addr| {
@@ -100,7 +100,7 @@ fn connect_loopback() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn smoke_test() {
     each_ip(&mut |addr| {
@@ -121,7 +121,7 @@ fn smoke_test() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn read_eof() {
     each_ip(&mut |addr| {
@@ -141,7 +141,7 @@ fn read_eof() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn write_close() {
     each_ip(&mut |addr| {
@@ -171,7 +171,7 @@ fn write_close() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn multiple_connect_serial() {
     each_ip(&mut |addr| {
@@ -194,7 +194,7 @@ fn multiple_connect_serial() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn multiple_connect_interleaved_greedy_schedule() {
     const MAX: usize = 10;
@@ -232,7 +232,7 @@ fn multiple_connect_interleaved_greedy_schedule() {
     }
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn multiple_connect_interleaved_lazy_schedule() {
     const MAX: usize = 10;
@@ -268,7 +268,7 @@ fn multiple_connect_interleaved_lazy_schedule() {
     }
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn socket_and_peer_name() {
     each_ip(&mut |addr| {
@@ -284,7 +284,7 @@ fn socket_and_peer_name() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn partial_read() {
     each_ip(&mut |addr| {
@@ -379,7 +379,7 @@ fn double_bind() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn tcp_clone_smoke() {
     each_ip(&mut |addr| {
@@ -411,7 +411,7 @@ fn tcp_clone_smoke() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn tcp_clone_two_read() {
     each_ip(&mut |addr| {
@@ -446,7 +446,7 @@ fn tcp_clone_two_read() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn tcp_clone_two_write() {
     each_ip(&mut |addr| {
@@ -474,7 +474,7 @@ fn tcp_clone_two_write() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 // FIXME: https://github.com/fortanix/rust-sgx/issues/110
 #[cfg_attr(target_env = "sgx", ignore)]
@@ -497,7 +497,7 @@ fn shutdown_smoke() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 // FIXME: https://github.com/fortanix/rust-sgx/issues/110
 #[cfg_attr(target_env = "sgx", ignore)]
@@ -538,7 +538,7 @@ fn close_readwrite_smoke() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 #[cfg(unix)] // test doesn't work on Windows, see #31657
 fn close_read_wakes_up() {
@@ -567,7 +567,7 @@ fn close_read_wakes_up() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn clone_while_reading() {
     each_ip(&mut |addr| {
@@ -608,7 +608,7 @@ fn clone_while_reading() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn clone_accept_smoke() {
     each_ip(&mut |addr| {
@@ -627,7 +627,7 @@ fn clone_accept_smoke() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn clone_accept_concurrent() {
     each_ip(&mut |addr| {
@@ -882,7 +882,7 @@ fn set_nonblocking() {
     }
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 #[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
 fn peek() {
@@ -926,46 +926,46 @@ fn connect_timeout_valid() {
 fn main() {
     bind_error();
     connect_error();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     listen_localhost();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     connect_loopback();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     smoke_test();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     read_eof();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     write_close();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     multiple_connect_serial();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     multiple_connect_interleaved_greedy_schedule();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     multiple_connect_interleaved_lazy_schedule();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     socket_and_peer_name();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     partial_read();
     read_vectored();
     write_vectored();
     double_bind();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     tcp_clone_smoke();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     tcp_clone_two_read();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     tcp_clone_two_write();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     shutdown_smoke();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     close_readwrite_smoke();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     close_read_wakes_up();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     clone_while_reading();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     clone_accept_smoke();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     clone_accept_concurrent();
     debug();
     timeouts();
@@ -976,7 +976,7 @@ fn main() {
     nodelay();
     ttl();
     set_nonblocking();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     peek();
     connect_timeout_valid();
 }

--- a/examples/net-udp.rs
+++ b/examples/net-udp.rs
@@ -16,9 +16,9 @@ use std::net::*;
 use std::os::unix::io::AsRawFd;
 #[cfg(windows)]
 use std::os::unix::io::AsRawSocket;
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 use std::sync::mpsc::channel;
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -44,7 +44,7 @@ fn bind_error() {
     }
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn socket_smoke_test_ip4() {
     each_ip(&mut |server_ip, client_ip| {
@@ -90,7 +90,7 @@ fn socket_peer() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn udp_clone_smoke() {
     each_ip(&mut |addr1, addr2| {
@@ -120,7 +120,7 @@ fn udp_clone_smoke() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn udp_clone_two_read() {
     each_ip(&mut |addr1, addr2| {
@@ -153,7 +153,7 @@ fn udp_clone_two_read() {
     })
 }
 
-#[cfg(feature = "thread")]
+#[cfg(feature = "threads")]
 //#[test]
 fn udp_clone_two_write() {
     each_ip(&mut |addr1, addr2| {
@@ -407,15 +407,15 @@ fn set_nonblocking() {
 
 fn main() {
     bind_error();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     socket_smoke_test_ip4();
     socket_name();
     socket_peer();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     udp_clone_smoke();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     udp_clone_two_read();
-    #[cfg(feature = "thread")]
+    #[cfg(feature = "threads")]
     udp_clone_two_write();
     debug();
     timeouts();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -61,16 +61,8 @@ fn test_example(name: &str, features: &str, stdout: &str, stderr: &str) {
     );
 
     // test-backtrace and test-tls are not fully supported by mustang yet.
-    // test-initialize-c-runtime deliberately links in C runtime symbols.
-    //
-    // Temporarily disable net-tcp and net-udp here until getsockopt,
-    // setsockopt, getaddrinfo, and freeaddrinfo are implemented.
-    if name != "test-backtrace"
-        && name != "test-tls"
-        && name != "test-initialize-c-runtime"
-        && name != "net-tcp"
-        && name != "net-udp"
-    {
+    // test-initialize-c-runtime deliberately link in C runtime symbols.
+    if name != "test-backtrace" && name != "test-tls" && name != "test-initialize-c-runtime" {
         let output = Command::new("nm")
             .arg("-u")
             .arg(&format!(
@@ -175,6 +167,7 @@ fn test() {
         "",
         ".｡oO(This process was started by origin! 🎯)\n\
 .｡oO(Environment variables initialized by c-scape! 🌱)\n\
+.｡oO(I/O performed by c-scape using rsix! 🌊)\n\
 .｡oO(This process will be exited by c-scape using rsix! 🚪)\n",
     );
     test_example(
@@ -183,6 +176,23 @@ fn test() {
         "",
         ".｡oO(This process was started by origin! 🎯)\n\
 .｡oO(Environment variables initialized by c-scape! 🌱)\n\
+.｡oO(This process will be exited by c-scape using rsix! 🚪)\n",
+    );
+    test_example(
+        "net-ip",
+        "",
+        "",
+        ".｡oO(This process was started by origin! 🎯)\n\
+.｡oO(Environment variables initialized by c-scape! 🌱)\n\
+.｡oO(This process will be exited by c-scape using rsix! 🚪)\n",
+    );
+    test_example(
+        "net-addr",
+        "",
+        "",
+        ".｡oO(This process was started by origin! 🎯)\n\
+.｡oO(Environment variables initialized by c-scape! 🌱)\n\
+.｡oO(I/O performed by c-scape using rsix! 🌊)\n\
 .｡oO(This process will be exited by c-scape using rsix! 🚪)\n",
     );
     test_example(


### PR DESCRIPTION
This implements enough of `getaddrinfo`, `freeaddrinfo`, `gai_strerror`,
`gethostname`, `getsockopt`, and `setsockopt` to pass all of `std`'s
in-tree tests that don't use threads.

Fixes #21.