### PR TITLE
Use `dlmalloc` as the default allocator.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,11 @@ ctor = "0.1.21"
 #core_simd = { git = "https://github.com/rust-lang/portable-simd" }
 
 [features]
-default = ["threads"]
+default = ["threads", "default-alloc"]
 threads = ["origin/threads", "mustang/threads"]
+default-alloc = ["mustang/default-alloc"]
+dlmalloc = ["mustang/dlmalloc"]
+wee_alloc = ["mustang/wee_alloc"]
 env_logger = ["origin/env_logger"]
 
 [workspace]

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 once_cell = "1.8.0"
 libm = "0.2.1"
-rsix = "0.23.7"
+rsix = "0.23.8"
 memoffset = "0.6"
 realpath-ext = "0.1.0"
 compiler_builtins = { version = "0.1.50", features = ["mem", "mangled-names"] }

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -23,9 +23,6 @@ origin = { path = "../origin", default-features = false }
 parking_lot = "0.11.2"
 log = "0.4.14"
 
-# A minimal `global_allocator` implementation.
-wee_alloc = "0.4.5"
-
 # When requested, check against libc signatures.
 [target.'cfg(mustang_use_libc)'.dependencies]
 libc = "0.2.99"
@@ -36,7 +33,7 @@ static_assertions = "1.1.0"
 paste = "1.0.5"
 
 [features]
-default = []
+default = ["threads"]
 threads = ["origin/threads"]
 
 [lib]

--- a/c-scape/README.md
+++ b/c-scape/README.md
@@ -1,4 +1,15 @@
-Selected libc, libpthread, and libunwind functions implemented in Rust.
+C-ABI-compatible libc, libm, libpthread, and libunwind interfaces, implemented
+in terms of crates written in Rust. Currently this only supports `*-*-linux-gnu`
+ABIs, though other ABIs could be added.
 
-This is currently highly experimental, spectacularly incomplete, and
-very unoptimized.
+The goal is to have very little code in `c-scape` itself, by factoring out all
+of the significant functionality into independent crates with more
+Rust-idiomatic APIs, with `c-scape` just wrapping those APIs to implement the
+C ABIs.
+
+This is currently experimental, incomplete, and some things aren't optimized.
+
+c-scape implements `malloc` using the Rust global allocator, and the default
+Rust global allocator is implemented using `malloc`, so it's necessary to
+enable a different global allocator. The `mustang` crate handles this
+automatically.

--- a/c-scape/src/data/linux_gnu.rs
+++ b/c-scape/src/data/linux_gnu.rs
@@ -29,8 +29,10 @@ pub(crate) const FIONBIO: c_long = 0x5421;
 pub(crate) const ALIGNOF_MAXALIGN_T: usize = 16;
 
 pub(crate) const MAP_ANONYMOUS: i32 = 32;
-
 pub(crate) const MAP_FAILED: *mut c_void = !0_usize as *mut c_void;
+pub(crate) const MREMAP_MAYMOVE: i32 = 1;
+pub(crate) const MREMAP_FIXED: i32 = 2;
+pub(crate) const MREMAP_DONTUNMAP: i32 = 4;
 
 pub(crate) const _SC_PAGESIZE: c_int = 30;
 pub(crate) const _SC_GETPW_R_SIZE_MAX: c_int = 70;

--- a/c-scape/src/data/mod.rs
+++ b/c-scape/src/data/mod.rs
@@ -95,6 +95,9 @@ constant_same_as!(
     std::mem::align_of::<libc::max_align_t>()
 );
 constant!(MAP_ANONYMOUS);
+constant!(MREMAP_MAYMOVE);
+constant!(MREMAP_FIXED);
+constant!(MREMAP_DONTUNMAP);
 constant_same_as!(MAP_FAILED, libc::MAP_FAILED);
 constant!(_SC_PAGESIZE);
 constant!(_SC_GETPW_R_SIZE_MAX);

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -22,11 +22,6 @@ mod pthread;
 mod raw_mutex;
 mod unwind;
 
-/// Link in `wee_alloc` as the global allocator, so that we don't call
-/// `malloc`.
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc<'static> = wee_alloc::WeeAlloc::INIT;
-
 /// Ensure that `mustang`'s modules are linked in.
 #[inline(never)]
 #[link_section = ".text.__mustang"]

--- a/c-scape/src/pthread.rs
+++ b/c-scape/src/pthread.rs
@@ -70,8 +70,8 @@ impl Default for pthread_attr_t {
 #[repr(C)]
 union pthread_mutex_u {
     // Use a custom `RawMutex` for non-reentrant pthread mutex for now, because
-    // we use `wee_alloc` for global allocations, it uses a mutex, and
-    // `parking_lot`'s `RawMutex` performs global allocations.
+    // we use `dlmalloc` or `wee_alloc` for global allocations, which use
+    // mutexes, and `parking_lot`'s `RawMutex` performs global allocations.
     normal: RawMutex,
     reentrant: parking_lot::lock_api::RawReentrantMutex<parking_lot::RawMutex, GetThreadId>,
 }

--- a/mustang/Cargo.toml
+++ b/mustang/Cargo.toml
@@ -10,10 +10,17 @@ license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 repository = "https://github.com/sunfishcode/mustang"
 edition = "2018"
 
+[dependencies]
+# A general-purpose `global_allocator` implementation.
+dlmalloc = { version = "0.2", features = ["global"], optional = true }
+# A small `global_allocator` implementation.
+wee_alloc = { version = "0.4", optional = true }
+
 [target.'cfg(target_vendor = "mustang")'.dependencies]
 origin = { path = "../origin", default-features = false }
 c-scape = { path = "../c-scape" }
 
 [features]
-default = []
+default = ["default-alloc", "threads"]
+default-alloc = ["dlmalloc"]
 threads = ["origin/threads", "c-scape/threads"]

--- a/mustang/README.md
+++ b/mustang/README.md
@@ -1,13 +1,16 @@
-This is the main public interface to `mustang`. It automatically
-pulls in crates to perform program initialization and termination,
-provide selected libc symbols, and registers a global allocator.
+Support crate for `*-mustang-*` targets.
 
-To use, add a `mustang` dependency to Cargo.toml, and add this line
-to your `main.rs`:
+In non-`*-mustang-*` targets, importing this crate has no effect.
+
+In `*-mustang-*` targets, this crate automatically pulls in crates to perform
+program initialization and termination, provide selected libc symbols, and
+registers a global allocator.
+
+To use, add a `mustang` dependency to Cargo.toml, and add this line to your
+`main.rs`:
 
 ```rust
 mustang::can_compile_this!();
 ```
 
-In `--target=*-mustang-*` builds, this activates `mustang` support.
-In all other targets, this has no effect.
+This macro expands to nothing in non-`*-mustang-*` builds.

--- a/mustang/src/lib.rs
+++ b/mustang/src/lib.rs
@@ -14,3 +14,20 @@ macro_rules! can_compile_this {
 extern crate c;
 #[cfg(target_vendor = "mustang")]
 extern crate origin;
+
+#[cfg(target_vendor = "mustang")]
+#[cfg(feature = "dlmalloc")]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
+
+#[cfg(target_vendor = "mustang")]
+#[cfg(feature = "wee_alloc")]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: wee_alloc::WeeAlloc<'static> = wee_alloc::WeeAlloc::INIT;
+
+// We need to enable some global allocator, because `c-scape` implements
+// `malloc` using the Rust global allocator, and the default Rust global
+// allocator uses `malloc`.
+#[cfg(target_vendor = "mustang")]
+#[cfg(not(any(feature = "dlmalloc", feature = "wee_alloc")))]
+compile_error!("Either feature \"dlmalloc\" or \"wee_alloc\" must be enabled for this crate.");

--- a/origin/Cargo.toml
+++ b/origin/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 linux-raw-sys = "0.0.28"
-rsix = "0.23.7"
+rsix = "0.23.8"
 bitflags = "1.3.0"
 once_cell = "1.8.0"
 log = "0.4.14"


### PR DESCRIPTION
The `dlmalloc` crate is a port of the dlmalloc library to Rust.

`wee_alloc` is specialized for small code size. Retain it as an option,
but use `dmalloc` by default, as it's a general-purpose allocator.

Also, move the `#[global_allocator]` code out of c-scape and into
mustang, as the roles for these crates are emerging. c-scape is focused
on providing C ABI compatibility, while mustang is focused on pulling
together all the pieces to support the *-mustang-* targets.

Fixes #28.