### PR TITLE
Rename `mustang::can_compile_this` to `mustang::can_run_this`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Then, in your own crate, add a dependency on `mustang`:
 mustang = { git = "https://github.com/sunfishcode/mustang" }
 ```
 
-And add a `mustang::can_compile_this!();` to your top-level module (eg. main.rs). This
-does nothing in non-`mustang`-target builds, but in `mustang`-target builds
-arranges for `mustang`'s libraries to be linked in.
+And add a `mustang::can_run_this!();` to your top-level module (eg. main.rs).
+This does nothing in non-`mustang`-target builds, but in `mustang`-target
+builds arranges for `mustang`'s libraries to be linked in.
 
 ```rust
-mustang::can_compile_this!();
+mustang::can_run_this!();
 ```
 
 Then, compile with Rust nightly, using `-Z build-std` and

--- a/examples/empty.rs
+++ b/examples/empty.rs
@@ -1,3 +1,3 @@
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 fn main() {}

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,4 +1,4 @@
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 fn main() {
     println!("Hello, world!");

--- a/examples/rust-by-example-threads.rs
+++ b/examples/rust-by-example-threads.rs
@@ -1,4 +1,4 @@
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 use std::thread;
 

--- a/examples/test-args.rs
+++ b/examples/test-args.rs
@@ -1,4 +1,4 @@
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 fn main() {
     let mut args = std::env::args_os();

--- a/examples/test-ctor.rs
+++ b/examples/test-ctor.rs
@@ -1,4 +1,4 @@
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 use std::ffi::{CStr, OsStr, OsString};
 use std::os::raw::{c_char, c_int};

--- a/examples/test-environ.rs
+++ b/examples/test-environ.rs
@@ -1,4 +1,4 @@
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 fn main() {
     // We expect to be passed some environment variables.

--- a/examples/test-simd.rs
+++ b/examples/test-simd.rs
@@ -2,7 +2,7 @@
 //#![feature(portable_simd)]
 //#![feature(asm)]
 
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 fn main() {
     // TODO: Re-enable test_simd when core_simd works on Rust nightly.

--- a/examples/test-tls.rs
+++ b/examples/test-tls.rs
@@ -1,4 +1,4 @@
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 use std::cell::Cell;
 use std::thread;

--- a/examples/test-workdir.rs
+++ b/examples/test-workdir.rs
@@ -1,4 +1,4 @@
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 fn main() {
     let _cwd = std::env::current_dir().expect("current directory should exist and be accessible");

--- a/mustang/README.md
+++ b/mustang/README.md
@@ -10,7 +10,7 @@ To use, add a `mustang` dependency to Cargo.toml, and add this line to your
 `main.rs`:
 
 ```rust
-mustang::can_compile_this!();
+mustang::can_run_this!();
 ```
 
 This macro expands to nothing in non-`*-mustang-*` builds.

--- a/mustang/src/lib.rs
+++ b/mustang/src/lib.rs
@@ -1,12 +1,12 @@
 #![doc = include_str!("../README.md")]
 
-/// Declare that a program can be compiled by `mustang`.
+/// Declare that a program can be compiled and run by `mustang`.
 ///
-/// To use this, put `mustang::can_compile_this!()` in the top-level
-/// `main.rs`. In `*-mustang-*` builds, this arranges for `mustang`
-/// libraries to be used. In all other builds, this does nothing.
+/// To use this, put `mustang::can_run_this!()` in the top-level `main.rs`. In
+/// `*-mustang-*` builds, this arranges for `mustang` libraries to be used. In
+/// all other builds, this does nothing.
 #[macro_export]
-macro_rules! can_compile_this {
+macro_rules! can_run_this {
     () => {};
 }
 

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -2,7 +2,7 @@
 //! library/std/src/env/tests.rs at revision
 //! 497ee321af3b8496eaccd7af7b437f18bab81abf.
 
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 use std::env::*;
 

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -1,7 +1,7 @@
 //! Run the programs in the `examples` directory and compare their outputs with
 //! expected outputs.
 
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 use similar_asserts::assert_eq;
 

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -7,7 +7,7 @@
 
 #![feature(io_error_uncategorized)]
 
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 mod sys_common;
 

--- a/tests/net-addr.rs
+++ b/tests/net-addr.rs
@@ -2,7 +2,7 @@
 //! library/std/src/net/addr/tests.rs at revision
 //! 497ee321af3b8496eaccd7af7b437f18bab81abf.
 
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 mod net;
 

--- a/tests/net-ip.rs
+++ b/tests/net-ip.rs
@@ -7,7 +7,7 @@
 #![feature(const_ipv4)]
 #![feature(const_ipv6)]
 
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 mod net;
 

--- a/tests/net-tcp.rs
+++ b/tests/net-tcp.rs
@@ -8,7 +8,7 @@
 #![feature(io_error_uncategorized)]
 #![feature(tcp_linger)]
 
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 mod net;
 

--- a/tests/net-udp.rs
+++ b/tests/net-udp.rs
@@ -5,7 +5,7 @@
 //! Currently everything is enabled except for the tests that use threads,
 //! which are marked with `#[cfg(feature = "threads")]`.
 
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 mod net;
 

--- a/tests/thread-local.rs
+++ b/tests/thread-local.rs
@@ -5,7 +5,7 @@
 #![feature(thread_local_const_init)]
 #![cfg(feature = "threads")]
 
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 use std::cell::{Cell, UnsafeCell};
 use std::sync::atomic::{AtomicU8, Ordering};

--- a/tests/thread.rs
+++ b/tests/thread.rs
@@ -8,7 +8,7 @@
 #![feature(box_syntax)]
 #![cfg(feature = "threads")]
 
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 use std::mem;
 use std::sync::mpsc::{channel, Sender};

--- a/tests/time.rs
+++ b/tests/time.rs
@@ -9,7 +9,7 @@
 #![feature(duration_constants)]
 #![allow(soft_unstable)]
 
-mustang::can_compile_this!();
+mustang::can_run_this!();
 
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 #[cfg(feature = "bench")]


### PR DESCRIPTION
Mustang isn't just about compiling programs, it's about running them
too! 😀