### PR TITLE
Rename `Thread::stack` to a `thread_stack` free function, and more tidying.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,12 @@ set the environment variable `CC_i686-mustang-linux-gnu` to
 
 Known limitations in `mustang` include:
 
- - Spawning new processes and unwinding panics are not implemented yet.
+ - Support for spawning processes (`std::process::*`) is not implemented yet [#34].
+ - Unwinding panics are not implemented yet ([#27]).
  - No support for dynamic linking yet.
+
+[#27]: https://github.com/sunfishcode/mustang/issues/27
+[#34]: https://github.com/sunfishcode/mustang/issues/34
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,25 @@ One probably needs to do similar things as for a new architecture, and also
 write a new `origin::rust` implementation to handle the OS's convention for
 arguments, environment variables, and initialization functions.
 
+## Similar crates
+
+c-scape has some similarities to [relibc], but has a different focus. Relibc is
+aiming to be a complete libc replacement, while c-scape is just aiming to cover
+the things used by Rust's `std` and popular crates. Some parts of Relibc are
+implemented in C, while c-scape is implemented entirely in Rust.
+
+c-scape is also similar to [steed]. See the Mustang README.md for details.
+
+The most significant thing that makes c-scape unique though is its design as a
+set of wrappers around Rust crates with Rust interfaces. C ABI compatibility is
+useful for getting existing code working, but once things are working, we can
+simplify and optimize by changing code to call into the Rust interfaces
+directly. This can eliminate many uses of raw pointers and C-style
+NUL-terminated strings, so it can be much safer.
+
+[relibc]: https://gitlab.redox-os.org/redox-os/relibc/
+[steed]: https://github.com/japaric/steed
+
 [`steed`]: https://github.com/japaric/steed
 [build-std]: https://doc.rust-lang.org/cargo/reference/unstable.html#build-std
 [Rust itself already does this]: https://github.com/rust-lang/rust/blob/6bed1f0bc3cc50c10aab26d5f94b16a00776b8a5/library/std/src/sys/unix/mod.rs#L71

--- a/c-scape/src/c.rs
+++ b/c-scape/src/c.rs
@@ -2275,16 +2275,16 @@ unsafe extern "C" fn getgid() -> c_uint {
 #[inline(never)]
 #[link_section = ".text.__mustang"]
 #[no_mangle]
-unsafe extern "C" fn kill() {
-    //libc!(kill());
+unsafe extern "C" fn kill(_pid: c_uint, _sig: c_int) -> c_int {
+    libc!(kill(_pid, _sig));
     unimplemented!("kill")
 }
 
 #[inline(never)]
 #[link_section = ".text.__mustang"]
 #[no_mangle]
-unsafe extern "C" fn raise() {
-    //libc!(raise());
+unsafe extern "C" fn raise(_sig: c_int) -> c_int {
+    libc!(raise(_sig));
     unimplemented!("raise")
 }
 

--- a/c-scape/src/exit.rs
+++ b/c-scape/src/exit.rs
@@ -29,6 +29,8 @@ unsafe extern "C" fn __cxa_finalize(_d: *mut c_void) {}
 #[link_section = ".text.__mustang"]
 #[no_mangle]
 unsafe extern "C" fn atexit(func: unsafe extern "C" fn()) -> c_int {
+    libc!(atexit(status));
+
     /// Adapter to let `atexit`-style functions be called in the same manner as
     /// `__cxa_atexit` functions.
     unsafe extern "C" fn adapter(func: *mut c_void) {
@@ -41,11 +43,12 @@ unsafe extern "C" fn atexit(func: unsafe extern "C" fn()) -> c_int {
 
 /// C-compatible `exit`.
 ///
-/// Call all the registered at-exit functions, and exit the process.
+/// Call all the registered at-exit functions, and exit the program.
 #[inline(never)]
 #[link_section = ".text.__mustang"]
 #[no_mangle]
 extern "C" fn exit(status: c_int) -> ! {
+    libc!(exit(status));
     origin::exit(status)
 }
 
@@ -56,6 +59,7 @@ extern "C" fn exit(status: c_int) -> ! {
 #[link_section = ".text.__mustang"]
 #[no_mangle]
 extern "C" fn _exit(status: c_int) -> ! {
+    libc!(_exit(status));
     origin::exit_immediately(status)
 }
 

--- a/c-scape/src/pthread.rs
+++ b/c-scape/src/pthread.rs
@@ -122,7 +122,7 @@ unsafe extern "C" fn pthread_self() -> pthread_t {
 #[no_mangle]
 unsafe extern "C" fn pthread_getattr_np(thread: pthread_t, attr: *mut pthread_attr_t) -> c_int {
     libc!(pthread_getattr_np(thread, same_ptr_mut(attr)));
-    let (stack_addr, stack_size, guard_size) = Thread::stack(thread as *mut Thread);
+    let (stack_addr, stack_size, guard_size) = origin::thread_stack(thread as *mut Thread);
     ptr::write(
         attr,
         pthread_attr_t {
@@ -528,12 +528,12 @@ unsafe extern "C" fn pthread_create(
     };
     assert!(stack_addr.is_null());
 
-    let thread_data = match origin::create_thread(fn_, arg, stack_size, guard_size) {
-        Ok(thread_data) => thread_data,
+    let thread = match origin::create_thread(fn_, arg, stack_size, guard_size) {
+        Ok(thread) => thread,
         Err(e) => return e.raw_os_error(),
     };
 
-    pthread.write(thread_data as pthread_t);
+    pthread.write(thread as pthread_t);
     0
 }
 

--- a/origin/Cargo.toml
+++ b/origin/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/sunfishcode/mustang"
 edition = "2018"
 
 [dependencies]
-linux-raw-sys = "0.0.28"
+linux-raw-sys = { version = "0.0.29", features = ["v5_4", "v5_11"] }
 rsix = "0.23.8"
 bitflags = "1.3.0"
 once_cell = "1.8.0"

--- a/origin/README.md
+++ b/origin/README.md
@@ -1,2 +1,7 @@
-origin is currently an implementation of a mostly C-compatible `_start` in
-Rust.
+origin implements program startup and shutdown, as well as thread startup and
+shutdown, for Linux, implemented in Rust.
+
+It is part of the [Mustang] project, building Rust programs written entirely
+in Rust.
+
+[Mustang]: https://github.com/sunfishcode/mustang/

--- a/origin/src/arch-x86_64.rs
+++ b/origin/src/arch-x86_64.rs
@@ -50,25 +50,25 @@ pub(super) unsafe fn clone(
 }
 
 #[inline]
-pub(super) unsafe fn set_thread_pointer(thread_data: *mut c_void) {
-    rsix::thread::tls::set_fs(thread_data);
-    debug_assert_eq!(*thread_data.cast::<*const c_void>(), thread_data);
-    debug_assert_eq!(get_thread_pointer(), thread_data);
+pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
+    rsix::thread::tls::set_fs(ptr);
+    debug_assert_eq!(*ptr.cast::<*const c_void>(), ptr);
+    debug_assert_eq!(get_thread_pointer(), ptr);
 }
 
 #[inline]
 pub(super) fn get_thread_pointer() -> *mut c_void {
-    let result;
+    let ptr;
     unsafe {
-        asm!("mov {},QWORD PTR fs:0", out(reg) result, options(nostack, preserves_flags, readonly));
+        asm!("mov {},QWORD PTR fs:0", out(reg) ptr, options(nostack, preserves_flags, readonly));
     }
-    result
+    ptr
 }
 
 /// `munmap` the current thread, then carefully exit the thread without
 /// touching the deallocated stack.
 #[inline]
-pub(super) unsafe fn deallocate_current(addr: *mut c_void, len: usize) -> ! {
+pub(super) unsafe fn munmap_and_exit_thread(map_addr: *mut c_void, map_len: usize) -> ! {
     asm!(
         "syscall",
         "xor edi,edi",
@@ -77,8 +77,8 @@ pub(super) unsafe fn deallocate_current(addr: *mut c_void, len: usize) -> ! {
         "ud2",
         __NR_exit = const __NR_exit,
         in("rax") __NR_munmap,
-        in("rdi") addr,
-        in("rsi") len,
+        in("rdi") map_addr,
+        in("rsi") map_len,
         options(noreturn, nostack)
     );
 }

--- a/origin/src/lib.rs
+++ b/origin/src/lib.rs
@@ -29,7 +29,7 @@ pub use program::{at_exit, exit, exit_immediately};
 #[cfg(feature = "threads")]
 pub use threads::{
     at_thread_exit, create_thread, current_thread, current_thread_id, default_guard_size,
-    default_stack_size, detach_thread, join_thread, Thread,
+    default_stack_size, detach_thread, join_thread, thread_stack, Thread,
 };
 
 /// The program entry point.

--- a/origin/src/threads.rs
+++ b/origin/src/threads.rs
@@ -651,33 +651,35 @@ static mut STARTUP_TLS_INFO: StartupTlsInfo = StartupTlsInfo {
     stack_size: 0,
 };
 
-// TODO: Move these into `rsix`?
+// We define `clone` and `CloneFlags` here in `origin` instead of `rsix`
+// because `clone` needs custom assembly code that knows about what we're
+// using it for.
 bitflags::bitflags! {
     struct CloneFlags: u32 {
-        const NEWTIME        = 0x0000_0080;
-        const VM             = 0x0000_0100;
-        const FS             = 0x0000_0200;
-        const FILES          = 0x0000_0400;
-        const SIGHAND        = 0x0000_0800;
-        const PIDFD          = 0x0000_1000;
-        const PTRACE         = 0x0000_2000;
-        const VFORK          = 0x0000_4000;
-        const PARENT         = 0x0000_8000;
-        const THREAD         = 0x0001_0000;
-        const NEWNS          = 0x0002_0000;
-        const SYSVSEM        = 0x0004_0000;
-        const SETTLS         = 0x0008_0000;
-        const PARENT_SETTID  = 0x0010_0000;
-        const CHILD_CLEARTID = 0x0020_0000;
-        const DETACHED       = 0x0040_0000;
-        const UNTRACED       = 0x0080_0000;
-        const CHILD_SETTID   = 0x0100_0000;
-        const NEWCGROUP      = 0x0200_0000;
-        const NEWUTS         = 0x0400_0000;
-        const NEWIPC         = 0x0800_0000;
-        const NEWUSER        = 0x1000_0000;
-        const NEWPID         = 0x2000_0000;
-        const NEWNET         = 0x4000_0000;
-        const IO             = 0x8000_0000;
+        const NEWTIME        = linux_raw_sys::v5_11::general::CLONE_NEWTIME; // since Linux 5.6
+        const VM             = linux_raw_sys::general::CLONE_VM;
+        const FS             = linux_raw_sys::general::CLONE_FS;
+        const FILES          = linux_raw_sys::general::CLONE_FILES;
+        const SIGHAND        = linux_raw_sys::general::CLONE_SIGHAND;
+        const PIDFD          = linux_raw_sys::v5_4::general::CLONE_PIDFD; // since Linux 5.2
+        const PTRACE         = linux_raw_sys::general::CLONE_PTRACE;
+        const VFORK          = linux_raw_sys::general::CLONE_VFORK;
+        const PARENT         = linux_raw_sys::general::CLONE_PARENT;
+        const THREAD         = linux_raw_sys::general::CLONE_THREAD;
+        const NEWNS          = linux_raw_sys::general::CLONE_NEWNS;
+        const SYSVSEM        = linux_raw_sys::general::CLONE_SYSVSEM;
+        const SETTLS         = linux_raw_sys::general::CLONE_SETTLS;
+        const PARENT_SETTID  = linux_raw_sys::general::CLONE_PARENT_SETTID;
+        const CHILD_CLEARTID = linux_raw_sys::general::CLONE_CHILD_CLEARTID;
+        const DETACHED       = linux_raw_sys::general::CLONE_DETACHED;
+        const UNTRACED       = linux_raw_sys::general::CLONE_UNTRACED;
+        const CHILD_SETTID   = linux_raw_sys::general::CLONE_CHILD_SETTID;
+        const NEWCGROUP      = linux_raw_sys::v5_4::general::CLONE_NEWCGROUP; // since Linux 4.6
+        const NEWUTS         = linux_raw_sys::general::CLONE_NEWUTS;
+        const NEWIPC         = linux_raw_sys::general::CLONE_NEWIPC;
+        const NEWUSER        = linux_raw_sys::general::CLONE_NEWUSER;
+        const NEWPID         = linux_raw_sys::general::CLONE_NEWPID;
+        const NEWNET         = linux_raw_sys::general::CLONE_NEWNET;
+        const IO             = linux_raw_sys::general::CLONE_IO;
     }
 }

--- a/origin/src/threads.rs
+++ b/origin/src/threads.rs
@@ -1,6 +1,6 @@
 //! Threads runtime.
 
-use crate::arch::{clone, get_thread_pointer, munmap_current, set_thread_pointer};
+use crate::arch::{clone, get_thread_pointer, munmap_and_exit_thread, set_thread_pointer};
 use memoffset::offset_of;
 use rsix::io;
 use rsix::process::{getrlimit, linux_execfn, page_size, Pid, Resource};


### PR DESCRIPTION
Rename `thread_data` variables to `thread`, to reflect that what used to
be `ThreadData` is now `Thread`. And tidy up other documentation and
comments.
