### PR TITLE
Make `origin` usable on non-`mustang` targets.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,6 +115,11 @@ jobs:
       run: |
         rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
 
+    - name: cargo check non-mustang
+      run: |
+        # Check that the code compiles on non-mustang targets.
+        cargo +nightly check
+
     - name: cargo test
       run: |
         cargo +nightly test --verbose --target=specs/x86_64-mustang-linux-gnu.json -Z build-std

--- a/origin/Cargo.toml
+++ b/origin/Cargo.toml
@@ -18,6 +18,9 @@ once_cell = "1.8.0"
 log = "0.4.14"
 memoffset = "0.6.4"
 
+[target.'cfg(not(target_vendor = "mustang"))'.dependencies]
+libc = "0.2.101"
+
 # Optional logging backend. You can use any external logger, but using this
 # feature allows origin to initialize the logger before main, so that you can
 # see the log messages emitted before main is called.

--- a/origin/src/arch-aarch64.rs
+++ b/origin/src/arch-aarch64.rs
@@ -41,6 +41,7 @@ pub(super) unsafe fn clone(
     r0
 }
 
+#[cfg(target_vendor = "mustang")]
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     asm!("msr tpidr_el0,{0}", in(reg) ptr);

--- a/origin/src/arch-riscv64.rs
+++ b/origin/src/arch-riscv64.rs
@@ -41,6 +41,7 @@ pub(super) unsafe fn clone(
     r0
 }
 
+#[cfg(target_vendor = "mustang")]
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     asm!("mv tp,{0}", in(reg) ptr);

--- a/origin/src/arch-x86.rs
+++ b/origin/src/arch-x86.rs
@@ -85,6 +85,7 @@ pub(super) unsafe fn clone(
     r0
 }
 
+#[cfg(target_vendor = "mustang")]
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     let mut user_desc = rsix::thread::tls::UserDesc {

--- a/origin/src/arch-x86_64.rs
+++ b/origin/src/arch-x86_64.rs
@@ -49,6 +49,7 @@ pub(super) unsafe fn clone(
     r0
 }
 
+#[cfg(target_vendor = "mustang")]
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     rsix::thread::tls::set_fs(ptr);

--- a/origin/src/lib.rs
+++ b/origin/src/lib.rs
@@ -4,7 +4,6 @@
 #![feature(naked_functions)]
 #![feature(link_llvm_intrinsics)]
 #![feature(atomic_mut_ptr)]
-#![cfg(target_vendor = "mustang")]
 
 mod program;
 #[cfg(feature = "threads")]
@@ -39,6 +38,7 @@ pub use threads::{
 /// This function should never be called explicitly. It is the first thing
 /// executed in the program, and it assumes that memory is laid out
 /// according to the operating system convention for starting a new program.
+#[cfg(target_vendor = "mustang")]
 #[naked]
 #[link_section = ".text.__mustang"]
 #[no_mangle]
@@ -90,12 +90,14 @@ unsafe impl Send for SendSyncVoidStar {}
 unsafe impl Sync for SendSyncVoidStar {}
 
 /// An ABI-conforming `__dso_handle`.
+#[cfg(target_vendor = "mustang")]
 #[link_section = ".data.__mustang"]
 #[no_mangle]
 #[used]
 static __dso_handle: SendSyncVoidStar = SendSyncVoidStar(&__dso_handle as *const _ as *mut c_void);
 
 /// Initialize logging, if enabled.
+#[cfg(target_vendor = "mustang")]
 #[cfg(feature = "env_logger")]
 #[link_section = ".init_array.00099"]
 #[used]
@@ -115,6 +117,7 @@ static INIT_ARRAY: unsafe extern "C" fn() = {
 };
 
 /// Ensure that this module is linked in.
+#[cfg(target_vendor = "mustang")]
 #[inline(never)]
 #[link_section = ".text.__mustang"]
 #[no_mangle]

--- a/origin/src/threads.rs
+++ b/origin/src/threads.rs
@@ -1,9 +1,13 @@
 //! Threads runtime.
 
-use crate::arch::{clone, get_thread_pointer, munmap_and_exit_thread, set_thread_pointer};
+#[cfg(target_vendor = "mustang")]
+use crate::arch::set_thread_pointer;
+use crate::arch::{clone, get_thread_pointer, munmap_and_exit_thread};
 use memoffset::offset_of;
 use rsix::io;
-use rsix::process::{getrlimit, linux_execfn, page_size, Pid, Resource};
+#[cfg(target_vendor = "mustang")]
+use rsix::process::{getrlimit, linux_execfn, Resource};
+use rsix::process::{page_size, Pid};
 use rsix::thread::gettid;
 use rsix::thread::tls::{set_tid_address, StartupTlsInfo};
 use std::cmp::max;
@@ -266,6 +270,7 @@ unsafe fn exit_thread() -> ! {
 /// This function is similar to `create_thread` except that the OS thread is
 /// already created, and already has a stack (which we need to locate), and is
 /// already running.
+#[cfg(target_vendor = "mustang")]
 pub(super) unsafe fn initialize_main_thread(mem: *mut c_void) {
     // Read the TLS information from the ELF header.
     STARTUP_TLS_INFO = rsix::thread::tls::startup_tls_info();


### PR DESCRIPTION
Origin's threading code can work on non-`mustang` targets, and with a
little extra code, it can use `libc` for `exit`/`atexit`, and be
minimally usable on non-`mustang`.

The main purpose of this, though, is to make the generated API
documentation for non-custom targets useful.