### PR TITLE
Add a feature to disable logging.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ default-alloc = ["mustang/default-alloc"]
 dlmalloc = ["mustang/dlmalloc"]
 wee_alloc = ["mustang/wee_alloc"]
 env_logger = ["origin/env_logger"]
+max_level_off = ["origin/max_level_off"]
 
 [workspace]
 members = [

--- a/origin/Cargo.toml
+++ b/origin/Cargo.toml
@@ -31,3 +31,6 @@ default = ["threads"]
 
 # Support for threads.
 threads = []
+
+# Disable logging.
+max_level_off = ["log/max_level_off"]


### PR DESCRIPTION
Logging adds some code size, so expose the log crate's cargo feature
"max_level_off", for disabling it.