### PR TITLE
force std to use of fork instead of clone3 in std::process

### DIFF
--- a/c-scape/src/data/linux_gnu.rs
+++ b/c-scape/src/data/linux_gnu.rs
@@ -63,6 +63,15 @@ pub(crate) const SYS_futex: c_long = 98;
 #[cfg(target_arch = "arm")]
 pub(crate) const SYS_futex: c_long = 240;
 
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "x86",
+    target_arch = "aarch64",
+    target_arch = "riscv64",
+    target_arch = "arm"
+))]
+pub(crate) const SYS_clone3: c_long = 435;
+
 pub(crate) const CLOCK_REALTIME: c_int = 0;
 pub(crate) const CLOCK_MONOTONIC: c_int = 1;
 

--- a/c-scape/src/data/mod.rs
+++ b/c-scape/src/data/mod.rs
@@ -109,6 +109,7 @@ constant!(_SC_SYMLOOP_MAX);
 constant_same_as!(SYMLOOP_MAX, unsafe { libc::sysconf(libc::_SC_SYMLOOP_MAX) });
 constant!(SYS_getrandom);
 constant!(SYS_futex);
+constant!(SYS_clone3);
 constant!(CLOCK_MONOTONIC);
 constant!(CLOCK_REALTIME);
 constant!(SIG_DFL);

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -2010,11 +2010,12 @@ unsafe extern "C" fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c
         if CStr::from_ptr(symbol).to_bytes() == b"getrandom" {
             return getrandom as *mut c_void;
         }
-        if CStr::from_ptr(symbol).to_bytes() == b"clone3" {
-            return clone3 as *mut c_void;
-        }
         if CStr::from_ptr(symbol).to_bytes() == b"copy_file_range" {
             return copy_file_range as *mut c_void;
+        }
+        if CStr::from_ptr(symbol).to_bytes() == b"clone3" {
+            // Let's just say we don't support this for now.
+            return null_mut();
         }
         if CStr::from_ptr(symbol).to_bytes() == b"__pthread_get_minstack" {
             // Let's just say we don't support this for now.
@@ -2263,6 +2264,11 @@ unsafe extern "C" fn syscall(number: c_long, mut args: ...) -> c_long {
                 Some(result) => result as _,
                 None => -1,
             }
+        }
+        data::SYS_clone3 => {
+            // ensure std::process uses fork as fallback code on linux
+            set_errno::<()>(Err(rsix::io::Error::NOSYS));
+            -1
         }
         _ => unimplemented!("syscall({:?})", number),
     }


### PR DESCRIPTION
simplifies the work needed to support `std::process` since `fork` is easier to implement than `clone3`.

EDIT: decided to wait for https://github.com/bytecodealliance/rsix/pull/91 first