### PR TITLE
Use `FnOnce` functions instead of `unsafe extern "C"` functions.

### DIFF
--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -47,7 +47,7 @@ use rsix::net::{
 use rsix::process::WaitOptions;
 use std::convert::TryInto;
 use std::ffi::{c_void, CStr, OsStr};
-use std::mem::{size_of, transmute, zeroed};
+use std::mem::{size_of, zeroed};
 use std::os::raw::{c_char, c_int, c_long, c_uint, c_ulong};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
@@ -3680,7 +3680,14 @@ unsafe extern "C" fn pthread_create(
     };
     assert!(stack_addr.is_null());
 
-    let thread = match origin::create_thread(fn_, arg, stack_size, guard_size) {
+    let thread = match origin::create_thread(
+        Box::new(move || {
+            fn_(arg);
+            Some(Box::new(arg))
+        }),
+        stack_size,
+        guard_size,
+    ) {
         Ok(thread) => thread,
         Err(e) => return e.raw_os_error(),
     };
@@ -3798,7 +3805,8 @@ unsafe extern "C" fn __cxa_thread_atexit_impl(
     _dso_symbol: *mut c_void,
 ) -> c_int {
     // TODO: libc!(__cxa_thread_atexit_impl(func, obj, _dso_symbol));
-    origin::at_thread_exit(func, obj);
+    let obj = obj as usize;
+    origin::at_thread_exit(Box::new(move || func(obj as *mut c_void)));
     0
 }
 
@@ -3815,7 +3823,8 @@ unsafe extern "C" fn __cxa_atexit(
     arg: *mut c_void,
     _dso: *mut c_void,
 ) -> c_int {
-    origin::at_exit(func, arg);
+    let arg = arg as usize;
+    origin::at_exit(Box::new(move || func(arg as *mut c_void)));
     0
 }
 
@@ -3826,14 +3835,7 @@ unsafe extern "C" fn __cxa_finalize(_d: *mut c_void) {}
 #[no_mangle]
 unsafe extern "C" fn atexit(func: extern "C" fn()) -> c_int {
     libc!(atexit(func));
-
-    /// Adapter to let `atexit`-style functions be called in the same manner as
-    /// `__cxa_atexit` functions.
-    unsafe extern "C" fn adapter(func: *mut c_void) {
-        transmute::<_, unsafe extern "C" fn()>(func)();
-    }
-
-    origin::at_exit(adapter, func as *mut c_void);
+    origin::at_exit(Box::new(move || func()));
     0
 }
 

--- a/origin/src/threads.rs
+++ b/origin/src/threads.rs
@@ -220,7 +220,7 @@ pub unsafe fn thread_stack(thread: *mut Thread) -> (*mut c_void, usize, usize) {
 ///
 /// This arranges for `func` to be called, and passed `obj`, when the thread
 /// exits.
-pub fn at_thread_exit(func: Box<dyn FnOnce() + Send>) {
+pub fn at_thread_exit(func: Box<dyn FnOnce()>) {
     // Safety: `current_thread()` points to thread-local data which is valid
     // as long as the thread is alive.
     unsafe {


### PR DESCRIPTION
Change origin's APIs which take callsbacks to take `Box<dyn FnOnce()>`
instead of `unsafe extern "C"` functions with `*mut c_void` callbacks,
so that `at_exit` and similar functions can be safe.

This also simplifies the `clone` assembly code sequences, as they no
longer need to pass a separate `arg` argument through, which previously
meant storing it on the child stack on some architectures.

It does, however, mean we double-`Box`, once to box up the `dyn Any`
object and another box so that we can get a single non-fat pointer to
it. If Rust ever gains a way to manipulate the raw parts of a fat
pointer and pass them through assembly code we might be able to avoid
this outer `Box`, but at present, double-`Box`ing seems to be the
recommended way.