### PR TITLE
move global allocator to c-scape

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,10 @@ ctor = "0.1.21"
 
 [features]
 default = ["threads", "default-alloc"]
-threads = ["origin/threads", "mustang/threads"]
-default-alloc = ["mustang/default-alloc"]
-dlmalloc = ["mustang/dlmalloc"]
-wee_alloc = ["mustang/wee_alloc"]
+threads = ["origin/threads", "mustang/threads", "c-scape/threads"]
+default-alloc = ["c-scape/default-alloc"]
+dlmalloc = ["c-scape/dlmalloc"]
+wee_alloc = ["c-scape/wee_alloc"]
 env_logger = ["origin/env_logger"]
 max_level_off = ["origin/max_level_off"]
 

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -22,6 +22,10 @@ sync-resolve = "0.3.0"
 origin = { path = "../origin", default-features = false, version = "^0.1.1-alpha.0"}
 parking_lot = "0.11.2"
 log = "0.4.14"
+# A general-purpose `global_allocator` implementation.
+dlmalloc = { version = "0.2", features = ["global"], optional = true }
+# A small `global_allocator` implementation.
+wee_alloc = { version = "0.4", optional = true }
 
 # When requested, check against libc signatures.
 [target.'cfg(mustang_use_libc)'.dependencies]
@@ -38,5 +42,6 @@ static_assertions = "1.1.0"
 paste = "1.0.5"
 
 [features]
-default = ["threads"]
+default = ["default-alloc", "threads"]
+default-alloc = ["dlmalloc"]
 threads = ["origin/threads"]

--- a/c-scape/src/allocator.rs
+++ b/c-scape/src/allocator.rs
@@ -1,0 +1,117 @@
+// We need to enable some global allocator, because `c-scape` implements
+// `malloc` using the Rust global allocator, and the default Rust global
+// allocator uses `malloc`.
+#[cfg(not(any(feature = "dlmalloc", feature = "wee_alloc")))]
+compile_error!("Either feature \"dlmalloc\" or \"wee_alloc\" must be enabled for this crate.");
+
+#[cfg(all(feature = "dlmalloc", not(feature = "threads")))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
+
+#[cfg(all(feature = "wee_alloc", not(feature = "threads")))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: wee_alloc::WeeAlloc<'static> = wee_alloc::WeeAlloc::INIT;
+
+#[cfg(all(any(feature = "dlmalloc", feature = "wee_alloc"), feature = "threads"))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: inner::GlobalAllocator = unsafe { inner::GlobalAllocator::new() };
+
+#[cfg(all(any(feature = "dlmalloc", feature = "wee_alloc"), feature = "threads"))]
+mod inner {
+    use crate::RawMutex;
+
+    use std::alloc::Layout;
+    #[cfg(feature = "dlmalloc")]
+    use std::cell::UnsafeCell;
+
+    pub struct GlobalAllocator {
+        pub(crate) mutex: RawMutex,
+        #[cfg(feature = "dlmalloc")]
+        inner: UnsafeCell<dlmalloc::Dlmalloc>,
+        #[cfg(feature = "wee_alloc")]
+        inner: wee_alloc::WeeAlloc<'static>,
+    }
+
+    #[cfg(feature = "dlmalloc")]
+    unsafe impl Sync for GlobalAllocator {}
+
+    impl GlobalAllocator {
+        pub(crate) const unsafe fn new() -> Self {
+            GlobalAllocator {
+                mutex: RawMutex::new(),
+                #[cfg(feature = "dlmalloc")]
+                inner: UnsafeCell::new(dlmalloc::Dlmalloc::new()),
+                #[cfg(feature = "wee_alloc")]
+                inner: wee_alloc::WeeAlloc::INIT,
+            }
+        }
+    }
+
+    #[macro_export]
+    macro_rules! with_mutex {
+        ( $mutex:expr, $exp:expr ) => {{
+            $mutex.lock();
+            let res = $exp;
+            $mutex.unlock();
+            res
+        }};
+    }
+
+    #[cfg(feature = "dlmalloc")]
+    unsafe impl std::alloc::GlobalAlloc for GlobalAllocator {
+        #[inline]
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            with_mutex!(
+                self.mutex,
+                (&mut *self.inner.get()).malloc(layout.size(), layout.align())
+            )
+        }
+
+        #[inline]
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            with_mutex!(
+                self.mutex,
+                (&mut *self.inner.get()).free(ptr, layout.size(), layout.align())
+            )
+        }
+
+        #[inline]
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            with_mutex!(
+                self.mutex,
+                (&mut *self.inner.get()).calloc(layout.size(), layout.align())
+            )
+        }
+
+        #[inline]
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            with_mutex!(
+                self.mutex,
+                (&mut *self.inner.get()).realloc(ptr, layout.size(), layout.align(), new_size)
+            )
+        }
+    }
+
+    #[cfg(feature = "wee_alloc")]
+    unsafe impl std::alloc::GlobalAlloc for GlobalAllocator {
+        #[inline]
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            with_mutex!(self.mutex, self.inner.alloc(layout))
+        }
+
+        #[inline]
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            with_mutex!(self.mutex, self.inner.dealloc(ptr, layout))
+        }
+
+        #[inline]
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            with_mutex!(self.mutex, self.inner.alloc_zeroed(layout))
+        }
+
+        #[inline]
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            with_mutex!(self.mutex, self.inner.realloc(ptr, layout, new_size))
+        }
+    }
+}

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -15,6 +15,7 @@ mod error_str;
 mod raw_mutex;
 // Unwinding isn't supported on 32-bit arm yet.
 // On aarch64 and riscg64 unwinding currently depends on a pre-release gimli.
+mod allocator;
 #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"))]
 mod unwind;
 

--- a/mustang/Cargo.toml
+++ b/mustang/Cargo.toml
@@ -16,11 +16,6 @@ edition = "2018"
 cc = { version = "1.0.68", optional = true }
 
 [dependencies]
-# A general-purpose `global_allocator` implementation.
-dlmalloc = { version = "0.2", features = ["global"], optional = true }
-# A small `global_allocator` implementation.
-wee_alloc = { version = "0.4", optional = true }
-
 # Enable "libc" and don't depend on "spin".
 # TODO: Eventually, we should propose a `fde-phdr-rsix` backend option to
 # upstream `unwinding` so that it doesn't need to go through `dl_iterate_phdr`,
@@ -42,6 +37,5 @@ origin = { path = "../origin", default-features = false, version = "^0.1.1-alpha
 c-scape = { path = "../c-scape", version = "^0.1.1-alpha.0"}
 
 [features]
-default = ["default-alloc", "threads"]
-default-alloc = ["dlmalloc"]
+default = ["threads"]
 threads = ["origin/threads", "c-scape/threads"]

--- a/mustang/src/lib.rs
+++ b/mustang/src/lib.rs
@@ -17,20 +17,3 @@ extern crate origin;
 #[cfg(not(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64")))]
 #[cfg(target_vendor = "mustang")]
 extern crate unwinding;
-
-#[cfg(target_vendor = "mustang")]
-#[cfg(feature = "dlmalloc")]
-#[global_allocator]
-static GLOBAL_ALLOCATOR: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
-
-#[cfg(target_vendor = "mustang")]
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static GLOBAL_ALLOCATOR: wee_alloc::WeeAlloc<'static> = wee_alloc::WeeAlloc::INIT;
-
-// We need to enable some global allocator, because `c-scape` implements
-// `malloc` using the Rust global allocator, and the default Rust global
-// allocator uses `malloc`.
-#[cfg(target_vendor = "mustang")]
-#[cfg(not(any(feature = "dlmalloc", feature = "wee_alloc")))]
-compile_error!("Either feature \"dlmalloc\" or \"wee_alloc\" must be enabled for this crate.");


### PR DESCRIPTION
this allows c-scape to lock the allocator by itself, without using `dlmalloc::enable_alloc_after_fork`, which deadlocks when used in mustang due to `pthread_atfork` allocating.