### PR TITLE
replace hashmap with tagged allocations for tracking allocation layout

### DIFF
--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -1651,6 +1651,9 @@ unsafe extern "C" fn posix_memalign(
     size: usize,
 ) -> c_int {
     libc!(posix_memalign(memptr, alignment, size));
+    if !(alignment.is_power_of_two() && alignment % std::mem::size_of::<*const c_void>() == 0) {
+        return rsix::io::Error::INVAL.raw_os_error();
+    }
 
     let layout = std::alloc::Layout::from_size_align(size, alignment).unwrap();
     let ptr = std::alloc::alloc(layout).cast::<_>();


### PR DESCRIPTION
this implements the tagging mentioned in https://github.com/sunfishcode/mustang/pull/59#issuecomment-955057932, to simplify the implementation of malloc.

`tagged_alloc`, `get_layout` and `tagged_dealloc` where seperately checked for correctness using miri.

also changed `posix_memalign` to be closer to its behavior in libc.