### PR TITLE
restore unwinding support for aarch64 and riscv64

### DIFF
--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -12,8 +12,7 @@ mod use_libc;
 mod data;
 mod error_str;
 // Unwinding isn't supported on 32-bit arm yet.
-// On aarch64 and riscg64 unwinding currently depends on a pre-release gimli.
-#[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"))]
+#[cfg(target_arch = "arm")]
 mod unwind;
 
 // Selected libc-compatible interfaces.

--- a/mustang/Cargo.toml
+++ b/mustang/Cargo.toml
@@ -20,7 +20,7 @@ cc = { version = "1.0.68", optional = true }
 # TODO: Eventually, we should propose a `fde-phdr-rustix` backend option to
 # upstream `unwinding` so that it doesn't need to go through `dl_iterate_phdr`,
 # but `fde-phdr-dl` works for now.
-[target.'cfg(not(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64")))'.dependencies.unwinding]
+[target.'cfg(not(target_arch = "arm"))'.dependencies.unwinding]
 version = "0.1.1"
 default-features = false
 features = [

--- a/mustang/Cargo.toml
+++ b/mustang/Cargo.toml
@@ -21,7 +21,7 @@ cc = { version = "1.0.68", optional = true }
 # upstream `unwinding` so that it doesn't need to go through `dl_iterate_phdr`,
 # but `fde-phdr-dl` works for now.
 [target.'cfg(not(target_arch = "arm"))'.dependencies.unwinding]
-version = "0.1.1"
+version = "0.1.3"
 default-features = false
 features = [
     "unwinder",

--- a/mustang/src/lib.rs
+++ b/mustang/src/lib.rs
@@ -14,6 +14,6 @@ macro_rules! can_run_this {
 extern crate c_scape;
 #[cfg(target_vendor = "mustang")]
 extern crate origin;
-#[cfg(not(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64")))]
+#[cfg(not(target_arch = "arm"))]
 #[cfg(target_vendor = "mustang")]
 extern crate unwinding;

--- a/specs/aarch64-mustang-linux-gnu.json
+++ b/specs/aarch64-mustang-linux-gnu.json
@@ -27,7 +27,8 @@
   "pre-link-args": {
     "gcc": [
       "-nostartfiles",
-      "-Wl,--undefined=__aarch64_swp4_rel"
+      "-Wl,--undefined=__aarch64_swp4_rel",
+      "-Wl,--undefined=_Unwind_Backtrace"
     ]
   },
   "vendor": "mustang"

--- a/specs/riscv64gc-mustang-linux-gnu.json
+++ b/specs/riscv64gc-mustang-linux-gnu.json
@@ -22,7 +22,8 @@
   "target-pointer-width": "64",
   "pre-link-args": {
     "gcc": [
-      "-nostartfiles"
+      "-nostartfiles",
+      "-Wl,--undefined=_Unwind_Backtrace"
     ]
   },
   "vendor": "mustang"

--- a/tests/lazy.rs
+++ b/tests/lazy.rs
@@ -43,13 +43,7 @@ fn lazy_default() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn lazy_poisoning() {
     let x: Lazy<String> = Lazy::new(|| panic!("kaboom"));
     for _ in 0..2 {
@@ -136,13 +130,7 @@ fn clone() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn get_or_try_init() {
     let cell: SyncOnceCell<String> = SyncOnceCell::new();
     assert!(cell.get().is_none());
@@ -267,13 +255,7 @@ fn static_sync_lazy_via_fn() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn sync_lazy_poisoning() {
     let x: SyncLazy<String> = SyncLazy::new(|| panic!("kaboom"));
     for _ in 0..2 {

--- a/tests/sync-mpsc.rs
+++ b/tests/sync-mpsc.rs
@@ -241,13 +241,7 @@ fn oneshot_single_thread_send_port_close() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn oneshot_single_thread_recv_chan_close() {
     // Receiving on a closed chan will panic
     let res = thread::spawn(move || {
@@ -328,13 +322,7 @@ fn oneshot_multi_task_recv_then_send() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn oneshot_multi_task_recv_then_close() {
     let (tx, rx) = channel::<Box<i32>>();
     let _t = thread::spawn(move || {
@@ -359,13 +347,7 @@ fn oneshot_multi_thread_close_stress() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn oneshot_multi_thread_send_close_stress() {
     for _ in 0..stress_factor() {
         let (tx, rx) = channel::<i32>();

--- a/tests/sync-mutex.rs
+++ b/tests/sync-mutex.rs
@@ -89,13 +89,7 @@ fn test_into_inner_drop() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_into_inner_poison() {
     let m = Arc::new(Mutex::new(NonCopy(10)));
     let m2 = m.clone();
@@ -120,13 +114,7 @@ fn test_get_mut() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_get_mut_poison() {
     let m = Arc::new(Mutex::new(NonCopy(10)));
     let m2 = m.clone();
@@ -198,13 +186,7 @@ fn test_arc_condvar_poison() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_mutex_arc_poison() {
     let arc = Arc::new(Mutex::new(1));
     assert!(!arc.is_poisoned());
@@ -235,13 +217,7 @@ fn test_mutex_arc_nested() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_mutex_arc_access_in_unwind() {
     let arc = Arc::new(Mutex::new(1));
     let arc2 = arc.clone();

--- a/tests/sync-once.rs
+++ b/tests/sync-once.rs
@@ -56,13 +56,7 @@ fn stampede_once() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn poison_bad() {
     static O: Once = Once::new();
 
@@ -91,13 +85,7 @@ fn poison_bad() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn wait_for_force_to_finish() {
     static O: Once = Once::new();
 

--- a/tests/sync-rwlock.rs
+++ b/tests/sync-rwlock.rs
@@ -50,13 +50,7 @@ fn frob() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_rw_arc_poison_wr() {
     let arc = Arc::new(RwLock::new(1));
     let arc2 = arc.clone();
@@ -69,13 +63,7 @@ fn test_rw_arc_poison_wr() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_rw_arc_poison_ww() {
     let arc = Arc::new(RwLock::new(1));
     assert!(!arc.is_poisoned());
@@ -90,13 +78,7 @@ fn test_rw_arc_poison_ww() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_rw_arc_no_poison_rr() {
     let arc = Arc::new(RwLock::new(1));
     let arc2 = arc.clone();
@@ -109,13 +91,7 @@ fn test_rw_arc_no_poison_rr() {
     assert_eq!(*lock, 1);
 }
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_rw_arc_no_poison_rw() {
     let arc = Arc::new(RwLock::new(1));
     let arc2 = arc.clone();
@@ -167,13 +143,7 @@ fn test_rw_arc() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_rw_arc_access_in_unwind() {
     let arc = Arc::new(RwLock::new(1));
     let arc2 = arc.clone();
@@ -250,13 +220,7 @@ fn test_into_inner_drop() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_into_inner_poison() {
     let m = Arc::new(RwLock::new(NonCopy(10)));
     let m2 = m.clone();
@@ -281,13 +245,7 @@ fn test_get_mut() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_get_mut_poison() {
     let m = Arc::new(RwLock::new(NonCopy(10)));
     let m2 = m.clone();

--- a/tests/thread.rs
+++ b/tests/thread.rs
@@ -41,13 +41,7 @@ fn test_named_thread() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 #[should_panic]
 fn test_invalid_named_thread() {
     let _ = Builder::new()
@@ -65,13 +59,7 @@ fn test_run_basic() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_join_panic() {
     match thread::spawn(move || panic!()).join() {
         result::Result::Err(_) => (),
@@ -174,13 +162,7 @@ fn test_simple_newsched_spawn() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_try_panic_message_static_str() {
     match thread::spawn(move || {
         panic!("static string");
@@ -197,13 +179,7 @@ fn test_try_panic_message_static_str() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_try_panic_message_owned_str() {
     match thread::spawn(move || {
         panic!("owned string".to_string());
@@ -220,13 +196,7 @@ fn test_try_panic_message_owned_str() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_try_panic_message_any() {
     match thread::spawn(move || {
         panic!(box 413u16 as Box<dyn Any + Send>);
@@ -245,13 +215,7 @@ fn test_try_panic_message_any() {
 }
 
 #[test]
-#[cfg_attr(
-    all(
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"),
-        not(feature = "unwinding")
-    ),
-    ignore
-)]
+#[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 fn test_try_panic_message_unit_struct() {
     struct Juju;
 


### PR DESCRIPTION
the version of `gimli` needed has been released and `unwinding` has been updated to use it