### PR TITLE
Mention C libraries as a known limitation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ Known limitations in `mustang` include:
 
  - No support for dynamic linking yet.
  - No support for `std::sync::Condvar` yet.
-
-[#34]: https://github.com/sunfishcode/mustang/issues/34
+ - Many missing features needed for libraries written in C.
 
 ## Background
 


### PR DESCRIPTION
Mustang completely replaces libc, but it doesn't yet have all the
features of a libc, in particular the "top half", which Rust code
doesn't use, but which is common to use from C.