### PR TITLE
Implement the `TIOCGWINSZ` ioctl.

### DIFF
--- a/c-scape/src/data/linux_gnu.rs
+++ b/c-scape/src/data/linux_gnu.rs
@@ -24,6 +24,7 @@ pub(crate) const DT_LNK: u8 = 10;
 pub(crate) const DT_SOCK: u8 = 12;
 
 pub(crate) const TCGETS: c_long = 0x5401;
+pub(crate) const TIOCGWINSZ: c_long = 0x5413;
 pub(crate) const FIONBIO: c_long = 0x5421;
 
 pub(crate) const ALIGNOF_MAXALIGN_T: usize = 16;

--- a/c-scape/src/data/mod.rs
+++ b/c-scape/src/data/mod.rs
@@ -89,6 +89,7 @@ constant!(DT_REG);
 constant!(DT_LNK);
 constant!(DT_SOCK);
 constant!(TCGETS);
+constant!(TIOCGWINSZ);
 constant!(FIONBIO);
 #[cfg(not(target_arch = "riscv64"))] // libc for riscv64 doesn't have max_align_t yet
 constant_same_as!(

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -1493,7 +1493,7 @@ unsafe extern "C" fn ioctl(fd: c_int, request: c_long, mut args: ...) -> c_int {
             let fd = BorrowedFd::borrow_raw_fd(fd);
             match set_errno(rustix::io::ioctl_tcgets(&fd)) {
                 Some(x) => {
-                    *args.arg::<*mut rustix::io::Termios>() = x;
+                    args.arg::<*mut rustix::io::Termios>().write(x);
                     0
                 }
                 None => -1,
@@ -1506,6 +1506,17 @@ unsafe extern "C" fn ioctl(fd: c_int, request: c_long, mut args: ...) -> c_int {
             let value = *ptr != 0;
             match set_errno(rustix::io::ioctl_fionbio(&fd, value)) {
                 Some(()) => 0,
+                None => -1,
+            }
+        }
+        data::TIOCGWINSZ => {
+            libc!(ioctl(fd, TIOCGWINSZ));
+            let fd = BorrowedFd::borrow_raw_fd(fd);
+            match set_errno(rustix::io::ioctl_tiocgwinsz(&fd)) {
+                Some(x) => {
+                    args.arg::<*mut rustix::io::Winsize>().write(x);
+                    0
+                }
                 None => -1,
             }
         }


### PR DESCRIPTION
This is a simple wrapper around `rustix::io::ioctl_tiocgwinsz`.