### PR TITLE
Document mustang's Linux kernel version support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ things with libc-compatible interfaces, just enough to allow it to slide in
 underneath `std`, however even this may not always be necessary. We'll see.
 
 Mustang currently runs on Rust Nightly on Linux on x86-64, aarch64, riscv64,
-x86, and arm.
+x86, and arm. It aims to support all Linux versions [supported by Rust], though
+at this time it's only tested on relatively recent versions.
+
+[supported by Rust]: https://doc.rust-lang.org/nightly/rustc/platform-support.html
 
 ## Usage
 


### PR DESCRIPTION
Mustang currently intends to support all Linux versions that Rust does,
however at this time the only CI testing we have is on relatively recent
Linux versions, because that's what common CI providers provide.