### PR TITLE
Start investigating the failing tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
             qemu_target: arm-linux-user
             host_target: armv5te-unknown-linux-gnueabi
             mustang_target: armv5te-mustang-linux-gnueabi
-            # when testing on armv5te, using more than 1 thread triggers a segfault
+            # FIXME(mustang): when testing on armv5te, using more than 1 thread triggers a segfault
             test_args: --test-threads 1
     steps:
     - uses: actions/checkout@v2

--- a/tests/net-addr.rs
+++ b/tests/net-addr.rs
@@ -18,7 +18,6 @@ fn to_socket_addr_ipaddr_u16() {
 }
 
 #[test]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn to_socket_addr_str_u16() {
     let a = sa4(Ipv4Addr::new(77, 88, 21, 11), 24352);
     assert_eq!(Ok(vec![a]), tsa(("77.88.21.11", 24352)));
@@ -34,7 +33,6 @@ fn to_socket_addr_str_u16() {
 }
 
 #[test]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn to_socket_addr_str() {
     let a = sa4(Ipv4Addr::new(77, 88, 21, 11), 24352);
     assert_eq!(Ok(vec![a]), tsa("77.88.21.11:24352"));
@@ -62,7 +60,6 @@ fn to_socket_addr_string() {
 }
 
 #[test]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn bind_udp_socket_bad() {
     // rust-lang/rust#53957: This is a regression test for a parsing problem
     // discovered as part of issue rust-lang/rust#23076, where we were

--- a/tests/net-tcp.rs
+++ b/tests/net-tcp.rs
@@ -60,7 +60,6 @@ fn connect_error() {
 
 #[cfg(feature = "threads")]
 #[test]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn listen_localhost() {
     let socket_addr = next_test_ip4();
     let listener = t!(TcpListener::bind(&socket_addr));
@@ -655,7 +654,6 @@ fn clone_accept_concurrent() {
 }
 
 #[test]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn debug() {
     #[cfg(not(target_env = "sgx"))]
     fn render_socket_addr<'a>(addr: &'a SocketAddr) -> impl fmt::Debug + 'a {
@@ -711,7 +709,6 @@ fn debug() {
 )]
 #[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
 #[test]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn timeouts() {
     let addr = next_test_ip4();
     let listener = t!(TcpListener::bind(&addr));
@@ -739,7 +736,6 @@ fn timeouts() {
 
 #[test]
 #[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn test_read_timeout() {
     let addr = next_test_ip4();
     let listener = t!(TcpListener::bind(&addr));
@@ -765,7 +761,6 @@ fn test_read_timeout() {
 
 #[test]
 #[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn test_read_with_timeout() {
     let addr = next_test_ip4();
     let listener = t!(TcpListener::bind(&addr));
@@ -817,7 +812,6 @@ fn test_timeout_zero_duration() {
 
 #[test]
 #[cfg_attr(target_env = "sgx", ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn linger() {
     let addr = next_test_ip4();
     let _listener = t!(TcpListener::bind(&addr));
@@ -833,7 +827,6 @@ fn linger() {
 
 #[test]
 #[cfg_attr(target_env = "sgx", ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn nodelay() {
     let addr = next_test_ip4();
     let _listener = t!(TcpListener::bind(&addr));
@@ -849,7 +842,6 @@ fn nodelay() {
 
 #[test]
 #[cfg_attr(target_env = "sgx", ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn ttl() {
     let ttl = 100;
 
@@ -867,7 +859,6 @@ fn ttl() {
 
 #[test]
 #[cfg_attr(target_env = "sgx", ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn set_nonblocking() {
     let addr = next_test_ip4();
     let listener = t!(TcpListener::bind(&addr));


### PR DESCRIPTION
This re-enables the net-tcp and net-addr tests, which pass for me locally, to see what they do in CI.

