### PR TITLE
Use the errno crate for setting errno.

### DIFF
--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -23,6 +23,7 @@ log = { version = "0.4.14", default-features = false }
 # We use the libc crate for C ABI types and constants, but we don't depend on
 # the actual platform libc.
 libc = { version = "0.2.108", default-features = false }
+errno = { version = "0.2.8", default-features = false }
 
 [build-dependencies]
 # Enable the cc dependency to build aarch64_outline_atomics from source

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -2402,7 +2402,7 @@ unsafe extern "C" fn syscall(number: c_long, mut args: ...) -> c_long {
         }
         libc::SYS_clone3 => {
             // ensure std::process uses fork as fallback code on linux
-            convert_res::<()>(Err(rustix::io::Error::NOSYS));
+            set_errno(Errno(libc::ENOSYS));
             -1
         }
         _ => unimplemented!("syscall({:?})", number),


### PR DESCRIPTION
Like the libc crate, the errno crate is implemented in Rust and supports
no_std.