### PR TITLE
Enable the `libc!` macros by default, and fix ensuing errors.

### DIFF
--- a/c-scape/src/use_libc.rs
+++ b/c-scape/src/use_libc.rs
@@ -1,23 +1,17 @@
 //! Utilities to check against C signatures, when enabled.
 
-#[cfg(mustang_use_libc)]
 macro_rules! libc {
     ($e:expr) => {
         // TODO: Implement actually using libc. Right now this is just a
         // signature check.
+        #[allow(unreachable_code)]
         if false {
             #[allow(unused_imports)]
             use crate::use_libc::*;
-            use ::libc::*;
-            // `dlopen` libc, `dlsym` the function, and call it...
+            // TODO: `dlopen` libc, `dlsym` the function, and call it...
             return $e;
         }
     };
-}
-
-#[cfg(not(mustang_use_libc))]
-macro_rules! libc {
-    ($e:expr) => {};
 }
 
 #[cfg(feature = "threads")]
@@ -36,14 +30,12 @@ macro_rules! libc_type {
     };
 }
 
-#[cfg(mustang_use_libc)]
 pub(crate) fn same_ptr<T, U>(t: *const T) -> *const U {
     assert_eq!(core::mem::size_of::<T>(), core::mem::size_of::<U>());
     assert_eq!(core::mem::align_of::<T>(), core::mem::align_of::<U>());
     t.cast::<U>()
 }
 
-#[cfg(mustang_use_libc)]
 pub(crate) fn same_ptr_mut<T, U>(t: *mut T) -> *mut U {
     assert_eq!(core::mem::size_of::<T>(), core::mem::size_of::<U>());
     assert_eq!(core::mem::align_of::<T>(), core::mem::align_of::<U>());


### PR DESCRIPTION
Now that mustang depends on the libc crate unconditionally, enable the
libc! macro checks by default.