### PR TITLE
implement compile checked pointer casts for libc signiture check

### DIFF
--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -154,7 +154,7 @@ unsafe extern "C" fn stat() -> c_int {
 
 #[no_mangle]
 unsafe extern "C" fn stat64(pathname: *const c_char, stat_: *mut rustix::fs::Stat) -> c_int {
-    libc!(checked_cast!(libc::stat64(pathname, stat_), stat_));
+    libc!(libc::stat64(pathname, checked_cast!(stat_)));
 
     match convert_res(rustix::fs::statat(
         &cwd(),
@@ -177,7 +177,7 @@ unsafe extern "C" fn fstat(_fd: c_int, _stat: *mut libc::stat) -> c_int {
 
 #[no_mangle]
 unsafe extern "C" fn fstat64(fd: c_int, stat_: *mut rustix::fs::Stat) -> c_int {
-    libc!(checked_cast!(libc::fstat64(fd, stat_), stat_));
+    libc!(libc::fstat64(fd, checked_cast!(stat_)));
 
     match convert_res(rustix::fs::fstat(&BorrowedFd::borrow_raw_fd(fd))) {
         Some(r) => {
@@ -197,10 +197,7 @@ unsafe extern "C" fn statx(
     mask: c_uint,
     stat_: *mut rustix::fs::Statx,
 ) -> c_int {
-    libc!(checked_cast!(
-        libc::statx(dirfd_, path, flags, mask, stat_),
-        stat_
-    ));
+    libc!(libc::statx(dirfd_, path, flags, mask, checked_cast!(stat_)));
 
     if path.is_null() || stat_.is_null() {
         set_errno(Errno(libc::EFAULT));
@@ -329,10 +326,7 @@ unsafe extern "C" fn fstatat64(
     stat_: *mut rustix::fs::Stat,
     flags: c_int,
 ) -> c_int {
-    libc!(checked_cast!(
-        libc::fstatat64(fd, pathname, stat_, flags),
-        stat_
-    ));
+    libc!(libc::fstatat64(fd, pathname, checked_cast!(stat_), flags));
 
     let flags = AtFlags::from_bits(flags as _).unwrap();
     match convert_res(rustix::fs::statat(
@@ -432,7 +426,7 @@ unsafe extern "C" fn lseek64(fd: c_int, offset: i64, whence: c_int) -> i64 {
 
 #[no_mangle]
 unsafe extern "C" fn lstat64(pathname: *const c_char, stat_: *mut rustix::fs::Stat) -> c_int {
-    libc!(checked_cast!(libc::lstat64(pathname, stat_), stat_));
+    libc!(libc::lstat64(pathname, checked_cast!(stat_)));
 
     match convert_res(rustix::fs::statat(
         &cwd(),
@@ -479,7 +473,11 @@ unsafe extern "C" fn readdir64_r(
     entry: *mut libc::dirent64,
     ptr: *mut *mut libc::dirent64,
 ) -> c_int {
-    libc!(libc::readdir64_r(dir.cast(), entry, ptr));
+    libc!(libc::readdir64_r(
+        dir.cast(),
+        checked_cast!(entry),
+        checked_cast!(ptr)
+    ));
 
     let dir = dir.cast::<rustix::fs::Dir>();
     match (*dir).read() {
@@ -697,7 +695,7 @@ unsafe extern "C" fn accept(
 ) -> c_int {
     // FIXME: layout of addr doesn't match signature on i686
     // uncomment once it does:
-    // libc!(checked_cast!(libc::accept(fd, addr, len), addr));
+    // libc!(libc::accept(fd, checked_cast!(addr), len));
     libc!(libc::accept(fd, addr.cast(), len));
 
     match convert_res(rustix::net::acceptfrom(&BorrowedFd::borrow_raw_fd(fd))) {
@@ -720,7 +718,7 @@ unsafe extern "C" fn accept4(
 ) -> c_int {
     // FIXME: layout of addr doesn't match signature on i686
     // uncomment once it does:
-    // libc!(checked_cast!(libc::accept4(fd, addr, len, flags), addr));
+    // libc!(libc::accept4(fd, checked_cast!(addr), len, flags));
     libc!(libc::accept4(fd, addr.cast(), len, flags));
 
     let flags = AcceptFlags::from_bits(flags as _).unwrap();
@@ -746,7 +744,7 @@ unsafe extern "C" fn bind(
 ) -> c_int {
     // FIXME: layout of addr doesn't match signature on i686
     // uncomment once it does:
-    // libc!(checked_cast!(libc::bind(sockfd, addr, len), addr));
+    // libc!(libc::bind(sockfd, checked_cast!(addr), len));
     libc!(libc::bind(sockfd, addr.cast(), len));
 
     let addr = match convert_res(SocketAddrAny::read(addr, len.try_into().unwrap())) {
@@ -775,7 +773,7 @@ unsafe extern "C" fn connect(
 ) -> c_int {
     // FIXME: layout of addr doesn't match signature on i686
     // uncomment once it does:
-    // libc!(checked_cast!(libc::connect(sockfd, addr, len), addr));
+    // libc!(libc::connect(sockfd, checked_cast!(addr), len));
     libc!(libc::connect(sockfd, addr.cast(), len));
 
     let addr = match convert_res(SocketAddrAny::read(addr, len.try_into().unwrap())) {
@@ -804,7 +802,7 @@ unsafe extern "C" fn getpeername(
 ) -> c_int {
     // FIXME: layout of addr doesn't match signature on i686
     // uncomment once it does:
-    // libc!(checked_cast!(libc::getpeername(fd, addr, len), addr));
+    // libc!(libc::getpeername(fd, checked_cast!(addr), len));
     libc!(libc::getpeername(fd, addr.cast(), len));
 
     match convert_res(rustix::net::getpeername(&BorrowedFd::borrow_raw_fd(fd))) {
@@ -826,7 +824,7 @@ unsafe extern "C" fn getsockname(
 ) -> c_int {
     // FIXME: layout of addr doesn't match signature on i686
     // uncomment once it does:
-    // libc!(checked_cast!(libc::getsockname(fd, addr, len), addr));
+    // libc!(libc::getsockname(fd, checked_cast!(addr), len));
     libc!(libc::getsockname(fd, addr.cast(), len));
 
     match convert_res(rustix::net::getsockname(&BorrowedFd::borrow_raw_fd(fd))) {
@@ -1109,7 +1107,12 @@ unsafe extern "C" fn getaddrinfo(
     hints: *const libc::addrinfo,
     res: *mut *mut libc::addrinfo,
 ) -> c_int {
-    libc!(libc::getaddrinfo(node, service, hints, res));
+    libc!(libc::getaddrinfo(
+        node,
+        service,
+        checked_cast!(hints),
+        checked_cast!(res)
+    ));
 
     assert!(service.is_null(), "service lookups not supported yet");
     assert!(!node.is_null(), "only name lookups are supported corrently");
@@ -1201,7 +1204,7 @@ unsafe extern "C" fn getaddrinfo(
 #[cfg(feature = "sync-resolve")]
 #[no_mangle]
 unsafe extern "C" fn freeaddrinfo(mut res: *mut libc::addrinfo) {
-    libc!(checked_cast!(libc::freeaddrinfo(res), res));
+    libc!(libc::freeaddrinfo(checked_cast!(res)));
 
     let layout = alloc::alloc::Layout::new::<libc::addrinfo>();
     let addr_layout = alloc::alloc::Layout::new::<SocketAddrStorage>();
@@ -1288,16 +1291,7 @@ unsafe extern "C" fn recvfrom(
 ) -> isize {
     // FIXME: layout of from doesn't match signature on i686
     // uncomment once it does:
-    /*
-    libc!(checked_cast!(libc::recvfrom(
-        fd,
-        buf,
-        len,
-        flags,
-        from,
-        from_len
-    ), from));
-    */
+    // libc!(libc::recvfrom(fd, buf, len, flags, checked_cast!(from), from_len));
     libc!(libc::recvfrom(fd, buf, len, flags, from.cast(), from_len));
 
     let flags = RecvFlags::from_bits(flags as _).unwrap();
@@ -1343,7 +1337,7 @@ unsafe extern "C" fn sendto(
 ) -> isize {
     // FIXME: layout of to doesn't match signature on i686
     // uncomment once it does:
-    //libc!(checked_cast!(libc::sendto(fd, buf, len, flags, to, to_len), to));
+    // libc!(libc::sendto(fd, buf, len, flags, checked_cast!(to), to_len));
     libc!(libc::sendto(fd, buf, len, flags, to.cast(), to_len));
 
     let flags = SendFlags::from_bits(flags as _).unwrap();
@@ -1461,7 +1455,7 @@ unsafe extern "C" fn write(fd: c_int, ptr: *const c_void, len: usize) -> isize {
 
 #[no_mangle]
 unsafe extern "C" fn writev(fd: c_int, iov: *const rustix::io::IoSlice, iovcnt: c_int) -> isize {
-    libc!(checked_cast!(libc::writev(fd, iov, iovcnt), iov));
+    libc!(libc::writev(fd, checked_cast!(iov), iovcnt));
 
     if iovcnt < 0 {
         set_errno(Errno(libc::EINVAL));
@@ -1492,7 +1486,7 @@ unsafe extern "C" fn read(fd: c_int, ptr: *mut c_void, len: usize) -> isize {
 
 #[no_mangle]
 unsafe extern "C" fn readv(fd: c_int, iov: *const rustix::io::IoSliceMut, iovcnt: c_int) -> isize {
-    libc!(checked_cast!(libc::readv(fd, iov, iovcnt), iov));
+    libc!(libc::readv(fd, checked_cast!(iov), iovcnt));
 
     if iovcnt < 0 {
         set_errno(Errno(libc::EINVAL));
@@ -1538,7 +1532,7 @@ unsafe extern "C" fn pwrite64(fd: c_int, ptr: *const c_void, len: usize, offset:
 
 #[no_mangle]
 unsafe extern "C" fn poll(fds: *mut rustix::io::PollFd, nfds: c_ulong, timeout: c_int) -> c_int {
-    libc!(checked_cast!(libc::poll(fds, nfds, timeout), fds));
+    libc!(libc::poll(checked_cast!(fds), nfds, timeout));
 
     let fds = slice::from_raw_parts_mut(fds, nfds.try_into().unwrap());
     match convert_res(rustix::io::poll(fds, timeout)) {
@@ -1673,7 +1667,7 @@ unsafe extern "C" fn epoll_ctl(
     _fd: c_int,
     _event: *mut libc::epoll_event,
 ) -> c_int {
-    libc!(libc::epoll_ctl(_epfd, _op, _fd, _event));
+    libc!(libc::epoll_ctl(_epfd, _op, _fd, checked_cast!(_event)));
     unimplemented!("epoll_ctl")
 }
 
@@ -1685,7 +1679,12 @@ unsafe extern "C" fn epoll_wait(
     _maxevents: c_int,
     _timeout: c_int,
 ) -> c_int {
-    libc!(libc::epoll_wait(_epfd, _events, _maxevents, _timeout));
+    libc!(libc::epoll_wait(
+        _epfd,
+        checked_cast!(_events),
+        _maxevents,
+        _timeout
+    ));
     unimplemented!("epoll_wait")
 }
 
@@ -2606,7 +2605,7 @@ unsafe extern "C" fn posix_spawn_file_actions_init(_ptr: *const c_void) -> c_int
 unsafe extern "C" fn clock_gettime(id: c_int, tp: *mut rustix::time::Timespec) -> c_int {
     // FIXME: layout of tp doesn't match signature on i686
     // uncomment once it does:
-    // libc!(checked_cast!(libc::clock_gettime(id, tp), tp));
+    // libc!(libc::clock_gettime(id, checked_cast!(tp)));
     libc!(libc::clock_gettime(id, tp.cast()));
 
     let id = match id {
@@ -2620,7 +2619,7 @@ unsafe extern "C" fn clock_gettime(id: c_int, tp: *mut rustix::time::Timespec) -
 
 #[no_mangle]
 unsafe extern "C" fn nanosleep(req: *const libc::timespec, rem: *mut libc::timespec) -> c_int {
-    libc!(libc::nanosleep(req, rem));
+    libc!(libc::nanosleep(checked_cast!(req), checked_cast!(rem)));
 
     let req = rustix::time::Timespec {
         tv_sec: (*req).tv_sec.into(),
@@ -3596,7 +3595,7 @@ unsafe extern "C" fn pthread_self() -> PthreadT {
 unsafe extern "C" fn pthread_getattr_np(thread: PthreadT, attr: *mut PthreadAttrT) -> c_int {
     // FIXME: layout of attr doesn't match signature on aarch64
     // uncomment once it does:
-    // libc!(checked_cast!(libc::pthread_getattr_np(thread, attr), attr));
+    // libc!(libc::pthread_getattr_np(thread, checked_cast!(attr)));
     let (stack_addr, stack_size, guard_size) = origin::thread_stack(thread as *mut Thread);
     ptr::write(
         attr,
@@ -3622,7 +3621,7 @@ unsafe extern "C" fn pthread_getattr_np(thread: PthreadT, attr: *mut PthreadAttr
 unsafe extern "C" fn pthread_attr_init(attr: *mut PthreadAttrT) -> c_int {
     // FIXME: layout of attr doesn't match signature on aarch64
     // uncomment once it does:
-    // libc!(checked_cast!(libc::pthread_attr_init(attr), attr));
+    // libc!(libc::pthread_attr_init(checked_cast!(attr)));
     ptr::write(attr, PthreadAttrT::default());
     0
 }
@@ -3632,7 +3631,7 @@ unsafe extern "C" fn pthread_attr_init(attr: *mut PthreadAttrT) -> c_int {
 unsafe extern "C" fn pthread_attr_destroy(attr: *mut PthreadAttrT) -> c_int {
     // FIXME: layout of attr doesn't match signature on aarch64
     // uncomment once it does:
-    // libc!(checked_cast!(libc::pthread_attr_destroy(attr), attr));
+    // libc!(libc::pthread_attr_destroy(checked_cast!(attr)));
     ptr::drop_in_place(attr);
     0
 }
@@ -3646,12 +3645,7 @@ unsafe extern "C" fn pthread_attr_getstack(
 ) -> c_int {
     // FIXME: layout of attr doesn't match signature on aarch64
     // uncomment once it does:
-    /*
-    libc!(checked_cast!(
-        libc::pthread_attr_getstack(attr, stackaddr, stacksize),
-        attr
-    ));
-    */
+    // libc!(libc::pthread_attr_getstack(checked_cast!(attr), stackaddr, stacksize));
     *stackaddr = (*attr).stack_addr;
     *stacksize = (*attr).stack_size;
     0
@@ -3698,7 +3692,7 @@ unsafe extern "C" fn pthread_key_delete() -> c_int {
 unsafe extern "C" fn pthread_mutexattr_destroy(attr: *mut PthreadMutexattrT) -> c_int {
     // FIXME: layout of attr doesn't match signature on aarch64
     // uncomment once it does:
-    // libc!(checked_cast!(libc::pthread_mutexattr_destroy(attr), attr));
+    // libc!(libc::pthread_mutexattr_destroy(checked_cast!(attr)));
     ptr::drop_in_place(attr);
     0
 }
@@ -3708,7 +3702,7 @@ unsafe extern "C" fn pthread_mutexattr_destroy(attr: *mut PthreadMutexattrT) -> 
 unsafe extern "C" fn pthread_mutexattr_init(attr: *mut PthreadMutexattrT) -> c_int {
     // FIXME: layout of attr doesn't match signature on aarch64
     // uncomment once it does:
-    // libc!(checked_cast!(libc::pthread_mutexattr_init(attr), attr));
+    // libc!(libc::pthread_mutexattr_init(checked_cast!(attr)));
     ptr::write(
         attr,
         PthreadMutexattrT {
@@ -3723,12 +3717,7 @@ unsafe extern "C" fn pthread_mutexattr_init(attr: *mut PthreadMutexattrT) -> c_i
 unsafe extern "C" fn pthread_mutexattr_settype(attr: *mut PthreadMutexattrT, kind: c_int) -> c_int {
     // FIXME: layout of attr doesn't match signature on aarch64
     // uncomment once it does:
-    /*
-    libc!(checked_cast!(
-        libc::pthread_mutexattr_settype(attr, kind),
-        attr
-    ));
-    */
+    // libc!(libc::pthread_mutexattr_settype(checked_cast!(attr), kind));
     (*attr).kind = AtomicU32::new(kind as u32);
     0
 }
@@ -3738,7 +3727,7 @@ unsafe extern "C" fn pthread_mutexattr_settype(attr: *mut PthreadMutexattrT, kin
 unsafe extern "C" fn pthread_mutex_destroy(mutex: *mut PthreadMutexT) -> c_int {
     // FIXME: layout of mutex doesn't match signature on aarch64
     // uncomment once it does:
-    // libc!(checked_cast!(libc::pthread_mutex_destroy(mutex), mutex));
+    // libc!(libc::pthread_mutex_destroy(checked_cast!(mutex)));
     match (*mutex).kind.load(SeqCst) as i32 {
         libc::PTHREAD_MUTEX_NORMAL => ptr::drop_in_place(&mut (*mutex).u.normal),
         libc::PTHREAD_MUTEX_RECURSIVE => ptr::drop_in_place(&mut (*mutex).u.reentrant),
@@ -3757,13 +3746,7 @@ unsafe extern "C" fn pthread_mutex_init(
 ) -> c_int {
     // FIXME: layout of mutex and attr doesn't match signature on aarch64
     // uncomment once it does:
-    /*
-    libc!(checked_cast!(
-        libc::pthread_mutex_init(mutex, mutexattr),
-        mutex,
-        mutexattr
-    ));
-    */
+    // libc!(libc::pthread_mutex_init(checked_cast!(mutex), checked_cast!(mutexattr)));
     let kind = (*mutexattr).kind.load(SeqCst);
     match kind as i32 {
         libc::PTHREAD_MUTEX_NORMAL => ptr::write(&mut (*mutex).u.normal, RawMutex::INIT),
@@ -3783,7 +3766,7 @@ unsafe extern "C" fn pthread_mutex_init(
 unsafe extern "C" fn pthread_mutex_lock(mutex: *mut PthreadMutexT) -> c_int {
     // FIXME: layout of mutex doesn't match signature on aarch64
     // uncomment once it does:
-    // libc!(checked_cast!(libc::pthread_mutex_lock(mutex), mutex));
+    // libc!(libc::pthread_mutex_lock(checked_cast!(mutex)));
     match (*mutex).kind.load(SeqCst) as i32 {
         libc::PTHREAD_MUTEX_NORMAL => (*mutex).u.normal.lock(),
         libc::PTHREAD_MUTEX_RECURSIVE => (*mutex).u.reentrant.lock(),
@@ -3798,7 +3781,7 @@ unsafe extern "C" fn pthread_mutex_lock(mutex: *mut PthreadMutexT) -> c_int {
 unsafe extern "C" fn pthread_mutex_trylock(mutex: *mut PthreadMutexT) -> c_int {
     // FIXME: layout of mutex doesn't match signature on aarch64
     // uncomment once it does:
-    // libc!(checked_cast!(libc::pthread_mutex_trylock(mutex), mutex));
+    // libc!(libc::pthread_mutex_trylock(checked_cast!(mutex)));
     if match (*mutex).kind.load(SeqCst) as i32 {
         libc::PTHREAD_MUTEX_NORMAL => (*mutex).u.normal.try_lock(),
         libc::PTHREAD_MUTEX_RECURSIVE => (*mutex).u.reentrant.try_lock(),
@@ -3816,7 +3799,7 @@ unsafe extern "C" fn pthread_mutex_trylock(mutex: *mut PthreadMutexT) -> c_int {
 unsafe extern "C" fn pthread_mutex_unlock(mutex: *mut PthreadMutexT) -> c_int {
     // FIXME: layout of mutex doesn't match signature on aarch64
     // uncomment once it does:
-    // libc!(checked_cast!(libc::pthread_mutex_unlock(mutex), mutex));
+    // libc!(libc::pthread_mutex_unlock(checked_cast!(mutex)));
     match (*mutex).kind.load(SeqCst) as i32 {
         libc::PTHREAD_MUTEX_NORMAL => (*mutex).u.normal.unlock(),
         libc::PTHREAD_MUTEX_RECURSIVE => (*mutex).u.reentrant.unlock(),
@@ -3829,10 +3812,7 @@ unsafe extern "C" fn pthread_mutex_unlock(mutex: *mut PthreadMutexT) -> c_int {
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_rwlock_tryrdlock(rwlock: *mut PthreadRwlockT) -> c_int {
-    libc!(checked_cast!(
-        libc::pthread_rwlock_tryrdlock(rwlock),
-        rwlock
-    ));
+    libc!(libc::pthread_rwlock_tryrdlock(checked_cast!(rwlock)));
     let result = (*rwlock).lock.try_lock_shared();
     if result {
         (*rwlock).exclusive.store(false, SeqCst);
@@ -3845,10 +3825,7 @@ unsafe extern "C" fn pthread_rwlock_tryrdlock(rwlock: *mut PthreadRwlockT) -> c_
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_rwlock_trywrlock(rwlock: *mut PthreadRwlockT) -> c_int {
-    libc!(checked_cast!(
-        libc::pthread_rwlock_trywrlock(rwlock),
-        rwlock
-    ));
+    libc!(libc::pthread_rwlock_trywrlock(checked_cast!(rwlock)));
     let result = (*rwlock).lock.try_lock_exclusive();
     if result {
         (*rwlock).exclusive.store(true, SeqCst);
@@ -3861,7 +3838,7 @@ unsafe extern "C" fn pthread_rwlock_trywrlock(rwlock: *mut PthreadRwlockT) -> c_
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_rwlock_rdlock(rwlock: *mut PthreadRwlockT) -> c_int {
-    libc!(checked_cast!(libc::pthread_rwlock_rdlock(rwlock), rwlock));
+    libc!(libc::pthread_rwlock_rdlock(checked_cast!(rwlock)));
     (*rwlock).lock.lock_shared();
     (*rwlock).exclusive.store(false, SeqCst);
     0
@@ -3870,7 +3847,7 @@ unsafe extern "C" fn pthread_rwlock_rdlock(rwlock: *mut PthreadRwlockT) -> c_int
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_rwlock_unlock(rwlock: *mut PthreadRwlockT) -> c_int {
-    libc!(checked_cast!(libc::pthread_rwlock_unlock(rwlock), rwlock));
+    libc!(libc::pthread_rwlock_unlock(checked_cast!(rwlock)));
     if (*rwlock).exclusive.load(SeqCst) {
         (*rwlock).lock.unlock_exclusive();
     } else {
@@ -3899,12 +3876,7 @@ unsafe extern "C" fn pthread_attr_getguardsize(
 ) -> c_int {
     // FIXME: layout of attr doesn't match signature on aarch64
     // uncomment once it does:
-    /*
-    libc!(checked_cast!(
-        libc::pthread_attr_getguardsize(attr, guardsize),
-        attr
-    ));
-    */
+    // libc!(libc::pthread_attr_getguardsize(checked_cast!(attr), guardsize));
     *guardsize = (*attr).guard_size;
     0
 }
@@ -3956,7 +3928,7 @@ libc_type!(PthreadCondattrT, pthread_condattr_t);
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_condattr_destroy(attr: *mut PthreadCondattrT) -> c_int {
-    libc!(checked_cast!(libc::pthread_condattr_destroy(attr), attr));
+    libc!(libc::pthread_condattr_destroy(checked_cast!(attr)));
     let _ = attr;
     rustix::io::write(
         &rustix::io::stderr(),
@@ -3969,7 +3941,7 @@ unsafe extern "C" fn pthread_condattr_destroy(attr: *mut PthreadCondattrT) -> c_
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_condattr_init(attr: *mut PthreadCondattrT) -> c_int {
-    libc!(checked_cast!(libc::pthread_condattr_init(attr), attr));
+    libc!(libc::pthread_condattr_init(checked_cast!(attr)));
     let _ = attr;
     rustix::io::write(
         &rustix::io::stderr(),
@@ -3985,9 +3957,9 @@ unsafe extern "C" fn pthread_condattr_setclock(
     attr: *mut PthreadCondattrT,
     clock_id: c_int,
 ) -> c_int {
-    libc!(checked_cast!(
-        libc::pthread_condattr_setclock(attr, clock_id),
-        attr
+    libc!(libc::pthread_condattr_setclock(
+        checked_cast!(attr),
+        clock_id
     ));
     let _ = (attr, clock_id);
     rustix::io::write(
@@ -4001,7 +3973,7 @@ unsafe extern "C" fn pthread_condattr_setclock(
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_cond_broadcast(cond: *mut PthreadCondT) -> c_int {
-    libc!(checked_cast!(libc::pthread_cond_broadcast(cond), cond));
+    libc!(libc::pthread_cond_broadcast(checked_cast!(cond)));
     let _ = cond;
     rustix::io::write(
         &rustix::io::stderr(),
@@ -4014,7 +3986,7 @@ unsafe extern "C" fn pthread_cond_broadcast(cond: *mut PthreadCondT) -> c_int {
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_cond_destroy(cond: *mut PthreadCondT) -> c_int {
-    libc!(checked_cast!(libc::pthread_cond_destroy(cond), cond));
+    libc!(libc::pthread_cond_destroy(checked_cast!(cond)));
     let _ = cond;
     rustix::io::write(
         &rustix::io::stderr(),
@@ -4030,10 +4002,9 @@ unsafe extern "C" fn pthread_cond_init(
     cond: *mut PthreadCondT,
     attr: *const PthreadCondattrT,
 ) -> c_int {
-    libc!(checked_cast!(
-        libc::pthread_cond_init(cond, attr),
-        cond,
-        attr
+    libc!(libc::pthread_cond_init(
+        checked_cast!(cond),
+        checked_cast!(attr)
     ));
     let _ = (cond, attr);
     rustix::io::write(&rustix::io::stderr(), b"unimplemented: pthread_cond_init\n").ok();
@@ -4043,7 +4014,7 @@ unsafe extern "C" fn pthread_cond_init(
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_cond_signal(cond: *mut PthreadCondT) -> c_int {
-    libc!(checked_cast!(libc::pthread_cond_signal(cond), cond));
+    libc!(libc::pthread_cond_signal(checked_cast!(cond)));
     let _ = cond;
     rustix::io::write(
         &rustix::io::stderr(),
@@ -4058,13 +4029,7 @@ unsafe extern "C" fn pthread_cond_signal(cond: *mut PthreadCondT) -> c_int {
 unsafe extern "C" fn pthread_cond_wait(cond: *mut PthreadCondT, lock: *mut PthreadMutexT) -> c_int {
     // FIXME: layout of lock doesn't match signature on aarch64
     // uncomment once it does:
-    /*
-    libc!(checked_cast!(
-        libc::pthread_cond_wait(cond, lock),
-        cond,
-        lock
-    ));
-    */
+    // libc!(libc::pthread_cond_wait(checked_cast!(cond), checked_cast!(lock));
     let _ = (cond, lock);
     rustix::io::write(&rustix::io::stderr(), b"unimplemented: pthread_cond_wait\n").ok();
     0
@@ -4079,13 +4044,7 @@ unsafe extern "C" fn pthread_cond_timedwait(
 ) -> c_int {
     // FIXME: layout of mutex doesn't match signature on aarch64
     // uncomment once it does:
-    /*
-    libc!(checked_cast!(
-        libc::pthread_cond_timedwait(cond, lock, abstime,),
-        cond,
-        lock
-    ));
-    */
+    // libc!(libc::pthread_cond_timedwait(checked_cast!(cond), checked_cast!(lock), abstime));
     let _ = (cond, lock, abstime);
     rustix::io::write(
         &rustix::io::stderr(),
@@ -4098,7 +4057,7 @@ unsafe extern "C" fn pthread_cond_timedwait(
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_rwlock_destroy(rwlock: *mut PthreadRwlockT) -> c_int {
-    libc!(checked_cast!(libc::pthread_rwlock_destroy(rwlock), rwlock));
+    libc!(libc::pthread_rwlock_destroy(checked_cast!(rwlock)));
     ptr::drop_in_place(rwlock);
     0
 }
@@ -4106,7 +4065,7 @@ unsafe extern "C" fn pthread_rwlock_destroy(rwlock: *mut PthreadRwlockT) -> c_in
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_rwlock_wrlock(rwlock: *mut PthreadRwlockT) -> c_int {
-    libc!(checked_cast!(libc::pthread_rwlock_wrlock(rwlock), rwlock));
+    libc!(libc::pthread_rwlock_wrlock(checked_cast!(rwlock)));
     (*rwlock).lock.lock_exclusive();
     (*rwlock).exclusive.store(true, SeqCst);
     0
@@ -4124,12 +4083,7 @@ unsafe extern "C" fn pthread_create(
 ) -> c_int {
     // FIXME: layout of attr doesn't match signature on aarch64
     // uncomment once it does:
-    /*
-    libc!(checked_cast!(
-        libc::pthread_create(pthread, attr, fn_, arg),
-        attr
-    ));
-    */
+    // libc!(libc::pthread_create(pthread, checked_cast!(attr), fn_, arg));
     let PthreadAttrT {
         stack_addr,
         stack_size,
@@ -4199,12 +4153,7 @@ unsafe extern "C" fn pthread_sigmask() -> c_int {
 unsafe extern "C" fn pthread_attr_setstacksize(attr: *mut PthreadAttrT, stacksize: usize) -> c_int {
     // FIXME: layout of attr doesn't match signature on aarch64
     // uncomment once it does:
-    /*
-    libc!(checked_cast!(
-        libc::pthread_attr_setstacksize(attr, stacksize),
-        attr
-    ));
-    */
+    // libc!(libc::pthread_attr_setstacksize(checked_cast!(attr), stacksize));
     (*attr).stack_size = stacksize;
     0
 }

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -693,7 +693,7 @@ unsafe extern "C" fn accept(
     addr: *mut SocketAddrStorage,
     len: *mut libc::socklen_t,
 ) -> c_int {
-    // FIXME: layout of addr doesn't match signature on i686
+    // FIXME(#95) layout of addr doesn't match signature on i686
     // uncomment once it does:
     // libc!(libc::accept(fd, checked_cast!(addr), len));
     libc!(libc::accept(fd, addr.cast(), len));
@@ -716,7 +716,7 @@ unsafe extern "C" fn accept4(
     len: *mut libc::socklen_t,
     flags: c_int,
 ) -> c_int {
-    // FIXME: layout of addr doesn't match signature on i686
+    // FIXME(#95) layout of addr doesn't match signature on i686
     // uncomment once it does:
     // libc!(libc::accept4(fd, checked_cast!(addr), len, flags));
     libc!(libc::accept4(fd, addr.cast(), len, flags));
@@ -742,7 +742,7 @@ unsafe extern "C" fn bind(
     addr: *const SocketAddrStorage,
     len: libc::socklen_t,
 ) -> c_int {
-    // FIXME: layout of addr doesn't match signature on i686
+    // FIXME(#95) layout of addr doesn't match signature on i686
     // uncomment once it does:
     // libc!(libc::bind(sockfd, checked_cast!(addr), len));
     libc!(libc::bind(sockfd, addr.cast(), len));
@@ -771,7 +771,7 @@ unsafe extern "C" fn connect(
     addr: *const SocketAddrStorage,
     len: libc::socklen_t,
 ) -> c_int {
-    // FIXME: layout of addr doesn't match signature on i686
+    // FIXME(#95) layout of addr doesn't match signature on i686
     // uncomment once it does:
     // libc!(libc::connect(sockfd, checked_cast!(addr), len));
     libc!(libc::connect(sockfd, addr.cast(), len));
@@ -800,7 +800,7 @@ unsafe extern "C" fn getpeername(
     addr: *mut SocketAddrStorage,
     len: *mut libc::socklen_t,
 ) -> c_int {
-    // FIXME: layout of addr doesn't match signature on i686
+    // FIXME(#95) layout of addr doesn't match signature on i686
     // uncomment once it does:
     // libc!(libc::getpeername(fd, checked_cast!(addr), len));
     libc!(libc::getpeername(fd, addr.cast(), len));
@@ -822,7 +822,7 @@ unsafe extern "C" fn getsockname(
     addr: *mut SocketAddrStorage,
     len: *mut libc::socklen_t,
 ) -> c_int {
-    // FIXME: layout of addr doesn't match signature on i686
+    // FIXME(#95) layout of addr doesn't match signature on i686
     // uncomment once it does:
     // libc!(libc::getsockname(fd, checked_cast!(addr), len));
     libc!(libc::getsockname(fd, addr.cast(), len));
@@ -1289,7 +1289,7 @@ unsafe extern "C" fn recvfrom(
     from: *mut SocketAddrStorage,
     from_len: *mut libc::socklen_t,
 ) -> isize {
-    // FIXME: layout of from doesn't match signature on i686
+    // FIXME(#95) layout of from doesn't match signature on i686
     // uncomment once it does:
     // libc!(libc::recvfrom(fd, buf, len, flags, checked_cast!(from), from_len));
     libc!(libc::recvfrom(fd, buf, len, flags, from.cast(), from_len));
@@ -1335,7 +1335,7 @@ unsafe extern "C" fn sendto(
     to: *const SocketAddrStorage,
     to_len: libc::socklen_t,
 ) -> isize {
-    // FIXME: layout of to doesn't match signature on i686
+    // FIXME(#95) layout of to doesn't match signature on i686
     // uncomment once it does:
     // libc!(libc::sendto(fd, buf, len, flags, checked_cast!(to), to_len));
     libc!(libc::sendto(fd, buf, len, flags, to.cast(), to_len));
@@ -2603,7 +2603,7 @@ unsafe extern "C" fn posix_spawn_file_actions_init(_ptr: *const c_void) -> c_int
 
 #[no_mangle]
 unsafe extern "C" fn clock_gettime(id: c_int, tp: *mut rustix::time::Timespec) -> c_int {
-    // FIXME: layout of tp doesn't match signature on i686
+    // FIXME(#95) layout of tp doesn't match signature on i686
     // uncomment once it does:
     // libc!(libc::clock_gettime(id, checked_cast!(tp)));
     libc!(libc::clock_gettime(id, tp.cast()));
@@ -3593,7 +3593,7 @@ unsafe extern "C" fn pthread_self() -> PthreadT {
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_getattr_np(thread: PthreadT, attr: *mut PthreadAttrT) -> c_int {
-    // FIXME: layout of attr doesn't match signature on aarch64
+    // FIXME(#95) layout of attr doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_getattr_np(thread, checked_cast!(attr)));
     let (stack_addr, stack_size, guard_size) = origin::thread_stack(thread as *mut Thread);
@@ -3619,7 +3619,7 @@ unsafe extern "C" fn pthread_getattr_np(thread: PthreadT, attr: *mut PthreadAttr
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_attr_init(attr: *mut PthreadAttrT) -> c_int {
-    // FIXME: layout of attr doesn't match signature on aarch64
+    // FIXME(#95) layout of attr doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_attr_init(checked_cast!(attr)));
     ptr::write(attr, PthreadAttrT::default());
@@ -3629,7 +3629,7 @@ unsafe extern "C" fn pthread_attr_init(attr: *mut PthreadAttrT) -> c_int {
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_attr_destroy(attr: *mut PthreadAttrT) -> c_int {
-    // FIXME: layout of attr doesn't match signature on aarch64
+    // FIXME(#95) layout of attr doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_attr_destroy(checked_cast!(attr)));
     ptr::drop_in_place(attr);
@@ -3643,7 +3643,7 @@ unsafe extern "C" fn pthread_attr_getstack(
     stackaddr: *mut *mut c_void,
     stacksize: *mut usize,
 ) -> c_int {
-    // FIXME: layout of attr doesn't match signature on aarch64
+    // FIXME(#95) layout of attr doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_attr_getstack(checked_cast!(attr), stackaddr, stacksize));
     *stackaddr = (*attr).stack_addr;
@@ -3690,7 +3690,7 @@ unsafe extern "C" fn pthread_key_delete() -> c_int {
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_mutexattr_destroy(attr: *mut PthreadMutexattrT) -> c_int {
-    // FIXME: layout of attr doesn't match signature on aarch64
+    // FIXME(#95) layout of attr doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_mutexattr_destroy(checked_cast!(attr)));
     ptr::drop_in_place(attr);
@@ -3700,7 +3700,7 @@ unsafe extern "C" fn pthread_mutexattr_destroy(attr: *mut PthreadMutexattrT) -> 
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_mutexattr_init(attr: *mut PthreadMutexattrT) -> c_int {
-    // FIXME: layout of attr doesn't match signature on aarch64
+    // FIXME(#95) layout of attr doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_mutexattr_init(checked_cast!(attr)));
     ptr::write(
@@ -3715,7 +3715,7 @@ unsafe extern "C" fn pthread_mutexattr_init(attr: *mut PthreadMutexattrT) -> c_i
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_mutexattr_settype(attr: *mut PthreadMutexattrT, kind: c_int) -> c_int {
-    // FIXME: layout of attr doesn't match signature on aarch64
+    // FIXME(#95) layout of attr doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_mutexattr_settype(checked_cast!(attr), kind));
     (*attr).kind = AtomicU32::new(kind as u32);
@@ -3725,7 +3725,7 @@ unsafe extern "C" fn pthread_mutexattr_settype(attr: *mut PthreadMutexattrT, kin
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_mutex_destroy(mutex: *mut PthreadMutexT) -> c_int {
-    // FIXME: layout of mutex doesn't match signature on aarch64
+    // FIXME(#95) layout of mutex doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_mutex_destroy(checked_cast!(mutex)));
     match (*mutex).kind.load(SeqCst) as i32 {
@@ -3744,7 +3744,7 @@ unsafe extern "C" fn pthread_mutex_init(
     mutex: *mut PthreadMutexT,
     mutexattr: *const PthreadMutexattrT,
 ) -> c_int {
-    // FIXME: layout of mutex and attr doesn't match signature on aarch64
+    // FIXME(#95) layout of mutex and attr doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_mutex_init(checked_cast!(mutex), checked_cast!(mutexattr)));
     let kind = (*mutexattr).kind.load(SeqCst);
@@ -3764,7 +3764,7 @@ unsafe extern "C" fn pthread_mutex_init(
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_mutex_lock(mutex: *mut PthreadMutexT) -> c_int {
-    // FIXME: layout of mutex doesn't match signature on aarch64
+    // FIXME(#95) layout of mutex doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_mutex_lock(checked_cast!(mutex)));
     match (*mutex).kind.load(SeqCst) as i32 {
@@ -3779,7 +3779,7 @@ unsafe extern "C" fn pthread_mutex_lock(mutex: *mut PthreadMutexT) -> c_int {
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_mutex_trylock(mutex: *mut PthreadMutexT) -> c_int {
-    // FIXME: layout of mutex doesn't match signature on aarch64
+    // FIXME(#95) layout of mutex doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_mutex_trylock(checked_cast!(mutex)));
     if match (*mutex).kind.load(SeqCst) as i32 {
@@ -3797,7 +3797,7 @@ unsafe extern "C" fn pthread_mutex_trylock(mutex: *mut PthreadMutexT) -> c_int {
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_mutex_unlock(mutex: *mut PthreadMutexT) -> c_int {
-    // FIXME: layout of mutex doesn't match signature on aarch64
+    // FIXME(#95) layout of mutex doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_mutex_unlock(checked_cast!(mutex)));
     match (*mutex).kind.load(SeqCst) as i32 {
@@ -3874,7 +3874,7 @@ unsafe extern "C" fn pthread_attr_getguardsize(
     attr: *const PthreadAttrT,
     guardsize: *mut usize,
 ) -> c_int {
-    // FIXME: layout of attr doesn't match signature on aarch64
+    // FIXME(#95) layout of attr doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_attr_getguardsize(checked_cast!(attr), guardsize));
     *guardsize = (*attr).guard_size;
@@ -4027,7 +4027,7 @@ unsafe extern "C" fn pthread_cond_signal(cond: *mut PthreadCondT) -> c_int {
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_cond_wait(cond: *mut PthreadCondT, lock: *mut PthreadMutexT) -> c_int {
-    // FIXME: layout of lock doesn't match signature on aarch64
+    // FIXME(#95) layout of lock doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_cond_wait(checked_cast!(cond), checked_cast!(lock));
     let _ = (cond, lock);
@@ -4042,7 +4042,7 @@ unsafe extern "C" fn pthread_cond_timedwait(
     lock: *mut PthreadMutexT,
     abstime: *const libc::timespec,
 ) -> c_int {
-    // FIXME: layout of mutex doesn't match signature on aarch64
+    // FIXME(#95) layout of mutex doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_cond_timedwait(checked_cast!(cond), checked_cast!(lock), abstime));
     let _ = (cond, lock, abstime);
@@ -4081,7 +4081,7 @@ unsafe extern "C" fn pthread_create(
     fn_: extern "C" fn(*mut c_void) -> *mut c_void,
     arg: *mut c_void,
 ) -> c_int {
-    // FIXME: layout of attr doesn't match signature on aarch64
+    // FIXME(#95) layout of attr doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_create(pthread, checked_cast!(attr), fn_, arg));
     let PthreadAttrT {
@@ -4151,7 +4151,7 @@ unsafe extern "C" fn pthread_sigmask() -> c_int {
 #[cfg(feature = "threads")]
 #[no_mangle]
 unsafe extern "C" fn pthread_attr_setstacksize(attr: *mut PthreadAttrT, stacksize: usize) -> c_int {
-    // FIXME: layout of attr doesn't match signature on aarch64
+    // FIXME(#95) layout of attr doesn't match signature on aarch64
     // uncomment once it does:
     // libc!(libc::pthread_attr_setstacksize(checked_cast!(attr), stacksize));
     (*attr).stack_size = stacksize;

--- a/c-scape/src/use_libc.rs
+++ b/c-scape/src/use_libc.rs
@@ -1,5 +1,29 @@
 //! Utilities to check against C signatures, when enabled.
 
+/// casts the given list of pointers to the type used by the given expression,
+/// while verifying that the layout of the pointee stays the same after the cast
+macro_rules! checked_cast {
+    ($expr:expr, $ptr:ident $( , $next:ident )* ) => {{
+        let result;
+        let target_ptr = {
+            let $ptr = $ptr.cast();
+            result = checked_cast!($expr $( , $next )* );
+            $ptr
+        };
+        // uses the fact that the compiler checks for size equality,
+        // when transmuting between types
+        let target = Pad::new(core::ptr::read(target_ptr));
+        let size_check = core::mem::transmute(core::ptr::read($ptr));
+        target.compare_size(size_check);
+        let align_check = core::mem::transmute(Pad::new(core::ptr::read($ptr)));
+        target.compare_alignment(align_check);
+        result
+    }};
+    ($expr:expr) => {
+        $expr
+    }
+}
+
 macro_rules! libc {
     ($e:expr) => {
         // TODO: Implement actually using libc. Right now this is just a
@@ -40,4 +64,30 @@ pub(crate) fn same_ptr_mut<T, U>(t: *mut T) -> *mut U {
     assert_eq!(core::mem::size_of::<T>(), core::mem::size_of::<U>());
     assert_eq!(core::mem::align_of::<T>(), core::mem::align_of::<U>());
     t.cast::<U>()
+}
+
+// based of the rules of C struct alignment:
+// align_of<Pad<T>> == max(align_of<T>, align_of<u8>) == align_of<T>,
+// size_of<Pad<T>> / align_of<Pad<T>>
+// == ciel( (size_of<T> + size_of<u8>) / align_of<Pad<T>>)
+// and size_of<T> is divisible by align_of<T>
+//
+// therefore size_of<Pad<T>> == size_of<T> + align_of<T>
+// so if size_of<T> == size_of<U> and size_of<<T>> == size_of<Pad<U>>
+// it follows that align_of<T> == align_of<U>
+#[repr(C)]
+pub(crate) struct Pad<T> {
+    field: T,
+    force_padding: u8,
+}
+
+impl<T> Pad<T> {
+    pub unsafe fn new(v: T) -> Self {
+        Pad {
+            field: v,
+            force_padding: 0,
+        }
+    }
+    pub fn compare_size(&self, _ptr: T) {}
+    pub fn compare_alignment(&self, _pad: Pad<T>) {}
 }

--- a/c-scape/src/use_libc.rs
+++ b/c-scape/src/use_libc.rs
@@ -54,15 +54,14 @@ macro_rules! libc_type {
     };
 }
 
+// a struct that adds align_of<T> padding bytes to type T
+//
 // based of the rules of C struct alignment:
 // align_of<Pad<T>> == max(align_of<T>, align_of<u8>) == align_of<T>,
 // size_of<Pad<T>> / align_of<Pad<T>>
 // == ciel( (size_of<T> + size_of<u8>) / align_of<Pad<T>>)
 // and size_of<T> is divisible by align_of<T>
-//
 // therefore size_of<Pad<T>> == size_of<T> + align_of<T>
-// so if size_of<T> == size_of<U> and size_of<<T>> == size_of<Pad<U>>
-// it follows that align_of<T> == align_of<U>
 #[repr(C)]
 pub(crate) struct Pad<T> {
     field: T,
@@ -76,6 +75,10 @@ impl<T> Pad<T> {
             force_padding: 0,
         }
     }
-    pub fn compare_size(&self, _ptr: T) {}
+    // used to check that size_of<T> == size_of<U> using transmute,
+    pub fn compare_size(&self, _v: T) {}
+    // used to check that size_of<Pad<T>> == size_of<Pad<U>> using transmute,
+    // and since size_of<Pad<T>> == size_of<T> + align_of<T>,
+    // if size_of<T> == size_of<U> then align_of<T> == align_of<U>
     pub fn compare_alignment(&self, _pad: Pad<T>) {}
 }

--- a/c-scape/src/use_libc.rs
+++ b/c-scape/src/use_libc.rs
@@ -54,18 +54,6 @@ macro_rules! libc_type {
     };
 }
 
-pub(crate) fn same_ptr<T, U>(t: *const T) -> *const U {
-    assert_eq!(core::mem::size_of::<T>(), core::mem::size_of::<U>());
-    assert_eq!(core::mem::align_of::<T>(), core::mem::align_of::<U>());
-    t.cast::<U>()
-}
-
-pub(crate) fn same_ptr_mut<T, U>(t: *mut T) -> *mut U {
-    assert_eq!(core::mem::size_of::<T>(), core::mem::size_of::<U>());
-    assert_eq!(core::mem::align_of::<T>(), core::mem::align_of::<U>());
-    t.cast::<U>()
-}
-
 // based of the rules of C struct alignment:
 // align_of<Pad<T>> == max(align_of<T>, align_of<u8>) == align_of<T>,
 // size_of<Pad<T>> / align_of<Pad<T>>

--- a/c-scape/src/use_libc.rs
+++ b/c-scape/src/use_libc.rs
@@ -1,14 +1,14 @@
 //! Utilities to check against C signatures, when enabled.
 
-/// casts the given pointer to another type, similarly to calling `cast()` on it,
-/// while verifying that the layout of the pointee stays the same after the cast
+/// Casts the given pointer to another type, similarly to calling `cast()` on it,
+/// while verifying that the layout of the pointee stays the same after the cast.
 macro_rules! checked_cast {
     ($ptr:ident) => {{
         let target_ptr = $ptr.cast();
         let target = Pad::new(core::ptr::read(target_ptr));
 
-        // uses the fact that the compiler checks for size equality,
-        // when transmuting between types
+        // Uses the fact that the compiler checks for size equality,
+        // when transmuting between types.
         let size_check = core::mem::transmute(core::ptr::read($ptr));
         target.compare_size(size_check);
         let align_check = core::mem::transmute(Pad::new(core::ptr::read($ptr)));
@@ -48,14 +48,14 @@ macro_rules! libc_type {
     };
 }
 
-// a struct that adds align_of<T> padding bytes to type T
-//
-// based of the rules of C struct alignment:
-// align_of<Pad<T>> == max(align_of<T>, align_of<u8>) == align_of<T>,
-// size_of<Pad<T>> / align_of<Pad<T>>
-// == ciel( (size_of<T> + size_of<u8>) / align_of<Pad<T>>)
-// and size_of<T> is divisible by align_of<T>
-// therefore size_of<Pad<T>> == size_of<T> + align_of<T>
+/// A struct that adds `align_of<T>` padding bytes to type `T`.
+///
+/// Based on the rules of C struct alignment:
+/// * `align_of<Pad<T>> == max(align_of<T>, align_of<u8>) == align_of<T>`
+/// * `size_of<Pad<T>> / align_of<Pad<T>> == ciel( (size_of<T> + size_of<u8>) / align_of<Pad<T>>)`
+/// * `size_of<T> % align_of<T> == 0`
+///
+/// Therefore `size_of<Pad<T>> == size_of<T> + align_of<T>`.
 #[repr(C)]
 pub(crate) struct Pad<T> {
     field: T,
@@ -69,10 +69,11 @@ impl<T> Pad<T> {
             force_padding: 0,
         }
     }
-    // used to check that size_of<T> == size_of<U> using transmute,
+    /// Used to check that `size_of<T> == size_of<U>` with `transmute`.
     pub fn compare_size(&self, _v: T) {}
-    // used to check that size_of<Pad<T>> == size_of<Pad<U>> using transmute,
-    // and since size_of<Pad<T>> == size_of<T> + align_of<T>,
-    // if size_of<T> == size_of<U> then align_of<T> == align_of<U>
+    /// Used to check that `size_of<Pad<T>> == size_of<Pad<U>>` with `transmute`.
+    ///
+    /// Since `size_of<Pad<T>> == size_of<T> + align_of<T>`,
+    /// if `size_of<T> == size_of<U>` then `align_of<T> == align_of<U>`.
     pub fn compare_alignment(&self, _pad: Pad<T>) {}
 }


### PR DESCRIPTION
implements compile time checks for casts by (ab)using `core::mem::transmute`,
successfully detected layout mismatch between `libc::stat` and `rustix::fs::Stat`, and between `libc::sockaddr` and `SocketAddrStorage` in i686,
and between pthread types of `libc` and of the crate in aarch64.

fixes #90