### PR TITLE
Implement `openat` and `unlinkat`.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
 
     - name: cargo test
       run: |
-        cargo +nightly test --verbose -Z build-std --target=specs/${{ matrix.mustang_target }}.json -- ${{ matrix.test_args }}
+        cargo +nightly test --verbose -Z build-std --target=specs/${{ matrix.mustang_target }}.json -- ${{ matrix.test_args }} -- --nocapture
       env:
         RUST_BACKTRACE: 1
 

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -115,13 +115,13 @@ unsafe extern "C" fn openat(
     fd: c_int,
     pathname: *const c_char,
     flags: c_int,
-    mode: c_int,
+    mode: libc::mode_t,
 ) -> c_int {
     libc!(libc::openat(fd, pathname, flags, mode));
 
     let fd = BorrowedFd::borrow_raw_fd(fd);
     let flags = OFlags::from_bits(flags as _).unwrap();
-    let mode = Mode::from_bits(mode as _).unwrap();
+    let mode = Mode::from_bits((mode & !libc::S_IFMT) as _).unwrap();
     match convert_res(rustix::fs::openat(
         &fd,
         ZStr::from_ptr(pathname.cast()),

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -121,7 +121,11 @@ unsafe extern "C" fn openat(
 
     let fd = BorrowedFd::borrow_raw_fd(fd);
     let flags = OFlags::from_bits(flags as _).unwrap();
-    let mode = Mode::from_bits((mode & !libc::S_IFMT) as _).unwrap();
+    let mode = if flags.contains(OFlags::CREATE) {
+        Mode::from_bits((mode & !libc::S_IFMT) as _).unwrap()
+    } else {
+        Mode::empty()
+    };
     match convert_res(rustix::fs::openat(
         &fd,
         ZStr::from_ptr(pathname.cast()),


### PR DESCRIPTION
Rust nightly now uses `openat` and `unlinkat`, so implement the C ABI
for these.