### PR TITLE
Handle rustix APIs which return optional addresses.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
   test:
     name: Test
     runs-on: ${{ matrix.os }}
+    env:
+      QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
         build: [ubuntu, ubuntu-18.04, i686-linux, aarch64-linux, riscv64-linux]
@@ -75,8 +77,15 @@ jobs:
 
     - name: Configure Cargo target
       run: |
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
+
+    - uses: actions/cache@v2
+      with:
+        path: ${{ runner.tool_cache }}/qemu
+        key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched
+      if: matrix.target != '' && matrix.os == 'ubuntu-latest'
 
     - name: Install cross-compilation tools
       run: |
@@ -103,24 +112,30 @@ jobs:
     - name: Install qemu
       run: |
         set -ex
+
+        # Configure Cargo for cross compilation and tell it how it can run
+        # cross executables
+        upcase=$(echo ${{ matrix.host_target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+        upcase=$(echo ${{ matrix.mustang_target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+
+        # See if qemu is already in the cache
+        if [ -f ${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} ]; then
+          exit 0
+        fi
+
         # Download and build qemu from source since the most recent release is
         # way faster at arm emulation than the current version github actions'
         # ubuntu image uses. Disable as much as we can to get it to build
         # quickly.
         cd
-        curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
-        cd qemu-6.1.0
+        curl https://download.qemu.org/qemu-$QEMU_BUILD_VERSION.tar.xz | tar xJf -
+        cd qemu-$QEMU_BUILD_VERSION
         patch -p1 < $GITHUB_WORKSPACE/ci/translate-errno.patch
         patch -p1 < $GITHUB_WORKSPACE/ci/getsockopt-timeouts.patch
-        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
-        make -j$(nproc) install
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
-        upcase=$(echo ${{ matrix.host_target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
-        upcase=$(echo ${{ matrix.mustang_target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache }}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        ninja -C build install
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
     - name: Install rust-src

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,6 +110,8 @@ jobs:
         cd
         curl https://download.qemu.org/qemu-6.1.0.tar.xz | tar xJf -
         cd qemu-6.1.0
+        patch -p1 < $GITHUB_WORKSPACE/ci/translate-errno.patch
+        patch -p1 < $GITHUB_WORKSPACE/ci/getsockopt-timeouts.patch
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         make -j$(nproc) install
 

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 libm = "0.2.1"
-rustix = { version = "0.33.0", default-features = false, features = ["itoa"] }
+rustix = { version = "0.33.3", default-features = false, features = ["itoa"] }
 memoffset = "0.6"
 realpath-ext = { version = "0.1.0", default-features = false }
 memchr = { version = "2.4.1", default-features = false }

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -2687,6 +2687,13 @@ unsafe extern "C" fn posix_spawn_file_actions_adddup2() {
 
 #[cfg(not(target_os = "wasi"))]
 #[no_mangle]
+unsafe extern "C" fn posix_spawn_file_actions_addchdir_np() {
+    //libc!(libc::posix_spawn_file_actions_addchdir_np());
+    unimplemented!("posix_spawn_file_actions_addchdir_np")
+}
+
+#[cfg(not(target_os = "wasi"))]
+#[no_mangle]
 unsafe extern "C" fn posix_spawn_file_actions_destroy(_ptr: *const c_void) -> c_int {
     //libc!(libc::posix_spawn_file_actions_destroy(ptr));
     rustix::io::write(

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -799,8 +799,10 @@ unsafe extern "C" fn accept(
 
     match convert_res(rustix::net::acceptfrom(&BorrowedFd::borrow_raw_fd(fd))) {
         Some((accepted_fd, from)) => {
-            let encoded_len = from.write(addr);
-            *len = encoded_len.try_into().unwrap();
+            if let Some(from) = from {
+                let encoded_len = from.write(addr);
+                *len = encoded_len.try_into().unwrap();
+            }
             accepted_fd.into_raw_fd()
         }
         None => -1,
@@ -826,8 +828,10 @@ unsafe extern "C" fn accept4(
         flags,
     )) {
         Some((accepted_fd, from)) => {
-            let encoded_len = from.write(addr);
-            *len = encoded_len.try_into().unwrap();
+            if let Some(from) = from {
+                let encoded_len = from.write(addr);
+                *len = encoded_len.try_into().unwrap();
+            }
             accepted_fd.into_raw_fd()
         }
         None => -1,
@@ -906,8 +910,10 @@ unsafe extern "C" fn getpeername(
 
     match convert_res(rustix::net::getpeername(&BorrowedFd::borrow_raw_fd(fd))) {
         Some(from) => {
-            let encoded_len = from.write(addr);
-            *len = encoded_len.try_into().unwrap();
+            if let Some(from) = from {
+                let encoded_len = from.write(addr);
+                *len = encoded_len.try_into().unwrap();
+            }
             0
         }
         None => -1,
@@ -1400,8 +1406,10 @@ unsafe extern "C" fn recvfrom(
         flags,
     )) {
         Some((nread, addr)) => {
-            let encoded_len = addr.write(from);
-            *from_len = encoded_len.try_into().unwrap();
+            if let Some(addr) = addr {
+                let encoded_len = addr.write(from);
+                *from_len = encoded_len.try_into().unwrap();
+            }
             nread as isize
         }
         None => -1,

--- a/ci/getsockopt-timeouts.patch
+++ b/ci/getsockopt-timeouts.patch
@@ -1,0 +1,80 @@
+From: Dan Gohman <dev@sunfishcode.online>
+Subject: [PATCH] Avoid storing unexpected values for `SO_RCVTIMEO_NEW` etc.
+
+This issue is reported upstream [here].
+
+[here]: https://gitlab.com/qemu-project/qemu/-/issues/885
+
+---
+ linux-user/generic/sockbits.h | 2 ++
+ linux-user/mips/sockbits.h    | 2 ++
+ linux-user/sparc/sockbits.h   | 2 ++
+ linux-user/syscall.c          | 6 ++++++
+ 4 files changed, 12 insertions(+)
+
+diff --git a/linux-user/generic/sockbits.h b/linux-user/generic/sockbits.h
+index b3b4a8e44c..f95747e3cc 100644
+--- a/linux-user/generic/sockbits.h
++++ b/linux-user/generic/sockbits.h
+@@ -36,6 +36,8 @@
+ #define TARGET_SO_SNDLOWAT     19
+ #define TARGET_SO_RCVTIMEO     20
+ #define TARGET_SO_SNDTIMEO     21
++#define TARGET_SO_RCVTIMEO_NEW 66
++#define TARGET_SO_SNDTIMEO_NEW 67
+ 
+ /* Security levels - as per NRL IPv6 - don't actually do anything */
+ #define TARGET_SO_SECURITY_AUTHENTICATION              22
+diff --git a/linux-user/mips/sockbits.h b/linux-user/mips/sockbits.h
+index 562cad88e2..4d411f7b61 100644
+--- a/linux-user/mips/sockbits.h
++++ b/linux-user/mips/sockbits.h
+@@ -39,6 +39,8 @@
+ #define TARGET_SO_RCVLOWAT     0x1004  /* receive low-water mark */
+ #define TARGET_SO_SNDTIMEO     0x1005  /* send timeout */
+ #define TARGET_SO_RCVTIMEO     0x1006  /* receive timeout */
++#define TARGET_SO_RCVTIMEO_NEW 66
++#define TARGET_SO_SNDTIMEO_NEW 67
+ #define TARGET_SO_ACCEPTCONN   0x1009
+ #define TARGET_SO_PROTOCOL     0x1028  /* protocol type */
+ #define TARGET_SO_DOMAIN       0x1029  /* domain/socket family */
+diff --git a/linux-user/sparc/sockbits.h b/linux-user/sparc/sockbits.h
+index 0a822e3e1f..8420ef9953 100644
+--- a/linux-user/sparc/sockbits.h
++++ b/linux-user/sparc/sockbits.h
+@@ -26,6 +26,8 @@
+ #define TARGET_SO_SNDLOWAT     0x1000
+ #define TARGET_SO_RCVTIMEO     0x2000
+ #define TARGET_SO_SNDTIMEO     0x4000
++#define TARGET_SO_RCVTIMEO_NEW 68
++#define TARGET_SO_SNDTIMEO_NEW 69
+ #define TARGET_SO_ACCEPTCONN   0x8000
+ 
+ #define TARGET_SO_SNDBUF       0x1001
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index a8eae3c4ac..8326e03a19 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -2348,6 +2348,9 @@ set_timeout:
+         case TARGET_SO_SNDTIMEO:
+                 optname = SO_SNDTIMEO;
+                 goto set_timeout;
++        case TARGET_SO_RCVTIMEO_NEW:
++        case TARGET_SO_SNDTIMEO_NEW:
++                return -TARGET_ENOPROTOOPT;
+         case TARGET_SO_ATTACH_FILTER:
+         {
+                 struct target_sock_fprog *tfprog;
+@@ -2595,6 +2598,9 @@ get_timeout:
+         case TARGET_SO_SNDTIMEO:
+             optname = SO_SNDTIMEO;
+             goto get_timeout;
++        case TARGET_SO_RCVTIMEO_NEW:
++        case TARGET_SO_SNDTIMEO_NEW:
++            return -TARGET_ENOPROTOOPT;
+         case TARGET_SO_PEERCRED: {
+             struct ucred cr;
+             socklen_t crlen;
+-- 
+2.32.0
+

--- a/ci/translate-errno.patch
+++ b/ci/translate-errno.patch
@@ -1,0 +1,28 @@
+From: Dan Gohman <dev@sunfishcode.online>
+Subject: [PATCH] Translate errno codes from host to target for `SO_ERROR`.
+
+This issue is reported upstream [here].
+
+[here]: https://gitlab.com/qemu-project/qemu/-/issues/872
+
+---
+ linux-user/syscall.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index b9b18a7eaf..a8eae3c4ac 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -2767,6 +2767,9 @@ get_timeout:
+         if (optname == SO_TYPE) {
+             val = host_to_target_sock_type(val);
+         }
++        if (level == SOL_SOCKET && optname == SO_ERROR) {
++            val = host_to_target_errno(val);
++        }
+         if (len > lv)
+             len = lv;
+         if (len == 4) {
+-- 
+2.32.0
+

--- a/origin/Cargo.toml
+++ b/origin/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 linux-raw-sys = { version = "0.0.40", default-features = false, features = ["general", "no_std"] }
-rustix = { version = "0.33.0", default-features = false }
+rustix = { version = "0.33.3", default-features = false }
 bitflags = "1.3.0"
 memoffset = { version = "0.6.4", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }


### PR DESCRIPTION
With bytecodealliance/rustix#219, rustix now returns addresses from some
socket functions wrapped in `Option`, to reflect the fact that some
network layers are unable to return sender or peer addresses.