### PR TITLE
Avoid casting pointers to usize and back.

### DIFF
--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -4373,8 +4373,11 @@ unsafe extern "C" fn __cxa_atexit(
     arg: *mut c_void,
     _dso: *mut c_void,
 ) -> c_int {
-    let arg = arg as usize;
-    origin::at_exit(Box::new(move || func(arg as *mut c_void)));
+    struct SendSync(*mut c_void);
+    unsafe impl Send for SendSync {}
+    unsafe impl Sync for SendSync {}
+    let arg = SendSync(arg);
+    origin::at_exit(Box::new(move || func(arg.0)));
     0
 }
 

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -2280,8 +2280,7 @@ unsafe extern "C" fn dl_iterate_phdr(
         static mut __executable_start: c_void;
     }
 
-    // Disabled for now, as our `dl_phdr_info` has fewer fields than libc's.
-    //libc!(libc::dl_iterate_phdr(callback, data));
+    libc!(libc::dl_iterate_phdr(callback, data));
 
     let (phdr, phnum) = rustix::runtime::exe_phdrs();
     let mut info = libc::dl_phdr_info {

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -2252,7 +2252,7 @@ unsafe extern "C" fn chdir(path: *const c_char) -> c_int {
 // so that it preserves provenance.
 #[no_mangle]
 unsafe extern "C" fn getauxval(type_: c_ulong) -> *mut c_void {
-    libc!(ptr::from_exposed_addr(libc::getauxval(type_) as _));
+    libc!(ptr::from_exposed_addr_mut(libc::getauxval(type_) as _));
     unimplemented!("unrecognized getauxval {}", type_)
 }
 

--- a/origin/src/arch-x86.rs
+++ b/origin/src/arch-x86.rs
@@ -71,7 +71,7 @@ pub(super) unsafe fn clone(
         "pop esi",
 
         entry = sym super::threads::entry,
-        inout("eax") &[newtls as usize, __NR_clone as usize, fn_ as usize] => r0,
+        inout("eax") &[newtls as *mut c_void, __NR_clone as *mut c_void, fn_ as *mut c_void] => r0,
         in("ebx") flags,
         in("ecx") child_stack,
         in("edx") parent_tid,

--- a/origin/src/lib.rs
+++ b/origin/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(naked_functions)]
 #![feature(link_llvm_intrinsics)]
 #![feature(atomic_mut_ptr)]
+#![feature(strict_provenance)]
 #![no_std]
 
 #[cfg(not(feature = "rustc-dep-of-std"))]

--- a/origin/src/program.rs
+++ b/origin/src/program.rs
@@ -110,8 +110,8 @@ pub(super) unsafe fn call_ctors(argc: c_int, argv: *mut *mut u8, envp: *mut *mut
 
     // Call the `.init_array` functions.
     type InitFn = fn(c_int, *mut *mut u8, *mut *mut u8);
-    let mut init = &__init_array_start as *const _ as usize as *const InitFn;
-    let init_end = &__init_array_end as *const _ as usize as *const InitFn;
+    let mut init = &__init_array_start as *const _ as *const InitFn;
+    let init_end = &__init_array_end as *const _ as *const InitFn;
     // Prevent the optimizer from optimizing the `!=` comparison to true;
     // `init` and `init_start` may have the same address.
     asm!("# {}", inout(reg) init);
@@ -187,8 +187,8 @@ pub fn exit(status: c_int) -> ! {
         }
 
         type InitFn = fn();
-        let mut fini: *const InitFn = &__fini_array_end as *const _ as usize as *const InitFn;
-        let fini_start: *const InitFn = &__fini_array_start as *const _ as usize as *const InitFn;
+        let mut fini: *const InitFn = &__fini_array_end as *const _ as *const InitFn;
+        let fini_start: *const InitFn = &__fini_array_start as *const _ as *const InitFn;
         // Prevent the optimizer from optimizing the `!=` comparison to true;
         // `fini` and `fini_start` may have the same address.
         asm!("# {}", inout(reg) fini);

--- a/origin/src/program.rs
+++ b/origin/src/program.rs
@@ -41,23 +41,23 @@ pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
 
         // Check that `mem` is where we expect it to be.
         debug_assert_ne!(mem, core::ptr::null_mut());
-        debug_assert_eq!(mem as usize & 0xf, 0);
-        debug_assert!((builtin_frame_address(0) as usize) <= mem as usize);
+        debug_assert_eq!(mem.addr() & 0xf, 0);
+        debug_assert!(builtin_frame_address(0).addr() <= mem.addr());
 
         // Check that the incoming stack pointer is where we expect it to be.
         debug_assert_eq!(builtin_return_address(0), core::ptr::null());
         debug_assert_ne!(builtin_frame_address(0), core::ptr::null());
         #[cfg(not(any(target_arch = "arm", target_arch = "x86")))]
-        debug_assert_eq!(builtin_frame_address(0) as usize & 0xf, 0);
+        debug_assert_eq!(builtin_frame_address(0).addr() & 0xf, 0);
         #[cfg(target_arch = "arm")]
-        debug_assert_eq!(builtin_frame_address(0) as usize & 0x7, 0);
+        debug_assert_eq!(builtin_frame_address(0).addr() & 0x7, 0);
         #[cfg(target_arch = "x86")]
-        debug_assert_eq!(builtin_frame_address(0) as usize & 0xf, 8);
+        debug_assert_eq!(builtin_frame_address(0).addr() & 0xf, 8);
         debug_assert_eq!(builtin_frame_address(1), core::ptr::null());
         #[cfg(target_arch = "aarch64")]
         debug_assert_ne!(builtin_sponentry(), core::ptr::null());
         #[cfg(target_arch = "aarch64")]
-        debug_assert_eq!(builtin_sponentry() as usize & 0xf, 0);
+        debug_assert_eq!(builtin_sponentry().addr() & 0xf, 0);
     }
 
     // Compute `argc`, `argv`, and `envp`.

--- a/origin/src/program.rs
+++ b/origin/src/program.rs
@@ -6,6 +6,7 @@ use crate::threads::initialize_main_thread;
 use alloc::boxed::Box;
 #[cfg(target_vendor = "mustang")]
 use alloc::vec::Vec;
+#[cfg(target_vendor = "mustang")]
 use core::arch::asm;
 use core::ffi::c_void;
 #[cfg(not(target_vendor = "mustang"))]

--- a/origin/src/threads.rs
+++ b/origin/src/threads.rs
@@ -389,7 +389,7 @@ pub(super) unsafe fn initialize_main_thread(mem: *mut c_void) {
     // See <https://lwn.net/Articles/631631/> for details.
     let execfn = linux_execfn().to_bytes_with_nul();
     let stack_base = execfn.as_ptr().add(execfn.len());
-    let stack_base = round_up(stack_base as usize, page_size()) as *mut c_void;
+    let stack_base = stack_base.map_addr(|ptr| round_up(ptr, page_size())) as *mut c_void;
 
     // We're running before any user code, so the startup soft stack limit is
     // the effective stack size. And Linux doesn't set up a guard page for the
@@ -450,7 +450,7 @@ pub(super) unsafe fn initialize_main_thread(mem: *mut c_void) {
 
     let tls_data = new.add(tls_data_bottom);
     let metadata: *mut Metadata = new.add(header).cast();
-    let newtls = (&mut (*metadata).abi) as *mut Abi;
+    let newtls: *mut Abi = &mut (*metadata).abi;
 
     // Initialize the thread metadata.
     ptr::write(
@@ -584,7 +584,7 @@ pub fn create_thread(
 
         let tls_data = map.add(tls_data_bottom);
         let metadata: *mut Metadata = map.add(header).cast();
-        let newtls = (&mut (*metadata).abi) as *mut Abi;
+        let newtls: *mut Abi = &mut (*metadata).abi;
 
         // Initialize the thread metadata.
         ptr::write(

--- a/origin/src/threads.rs
+++ b/origin/src/threads.rs
@@ -56,16 +56,16 @@ pub(super) unsafe extern "C" fn entry(fn_: *mut Box<dyn FnOnce() -> Option<Box<d
         debug_assert_eq!(builtin_return_address(0), core::ptr::null());
         debug_assert_ne!(builtin_frame_address(0), core::ptr::null());
         #[cfg(not(any(target_arch = "x86", target_arch = "arm")))]
-        debug_assert_eq!(builtin_frame_address(0) as usize & 0xf, 0);
+        debug_assert_eq!(builtin_frame_address(0).addr() & 0xf, 0);
         #[cfg(target_arch = "arm")]
-        debug_assert_eq!(builtin_frame_address(0) as usize & 0x3, 0);
+        debug_assert_eq!(builtin_frame_address(0).addr() & 0x3, 0);
         #[cfg(target_arch = "x86")]
-        debug_assert_eq!(builtin_frame_address(0) as usize & 0xf, 8);
+        debug_assert_eq!(builtin_frame_address(0).addr() & 0xf, 8);
         debug_assert_eq!(builtin_frame_address(1), core::ptr::null());
         #[cfg(target_arch = "aarch64")]
         debug_assert_ne!(builtin_sponentry(), core::ptr::null());
         #[cfg(target_arch = "aarch64")]
-        debug_assert_eq!(builtin_sponentry() as usize & 0xf, 0);
+        debug_assert_eq!(builtin_sponentry().addr() & 0xf, 0);
 
         // Check that `clone` stored our thread id as we expected.
         debug_assert_eq!(current_thread_id(), gettid());
@@ -446,7 +446,7 @@ pub(super) unsafe fn initialize_main_thread(mem: *mut c_void) {
     )
     .unwrap()
     .cast::<u8>();
-    debug_assert_eq!(new as usize % metadata_align, 0);
+    debug_assert_eq!(new.addr() % metadata_align, 0);
 
     let tls_data = new.add(tls_data_bottom);
     let metadata: *mut Metadata = new.add(header).cast();


### PR DESCRIPTION
To a first approximation, this makes origin and c-scape conform to
strict-provenance.