### PR TITLE
Enable the new strict-provenance lints.

### DIFF
--- a/c-scape/aarch64_outline_atomics/aarch64_outline_atomics/src/lib.rs
+++ b/c-scape/aarch64_outline_atomics/aarch64_outline_atomics/src/lib.rs
@@ -1,3 +1,7 @@
+#![feature(strict_provenance)]
+#![deny(fuzzy_provenance_casts)]
+#![deny(lossy_provenance_casts)]
+
 use core::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release};
 use core::sync::atomic::{AtomicU32, AtomicU64, AtomicU8};
 

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -7,6 +7,8 @@
 #![feature(untagged_unions)] // for `PthreadMutexT`
 #![feature(atomic_mut_ptr)] // for `RawMutex`
 #![feature(strict_provenance)]
+#![deny(fuzzy_provenance_casts)]
+#![deny(lossy_provenance_casts)]
 
 extern crate alloc;
 extern crate compiler_builtins;
@@ -2569,7 +2571,7 @@ unsafe extern "C" fn syscall(number: c_long, mut args: ...) -> *mut c_void {
             libc!(ptr::invalid_mut(
                 libc::syscall(libc::SYS_getrandom, buf, len, flags) as _
             ));
-            getrandom(buf, len, flags) as _
+            ptr::invalid_mut(getrandom(buf, len, flags) as _)
         }
         #[cfg(feature = "threads")]
         libc::SYS_futex => {
@@ -2621,7 +2623,7 @@ unsafe extern "C" fn syscall(number: c_long, mut args: ...) -> *mut c_void {
                 &new_timespec
             };
             match convert_res(futex(uaddr, op, flags, val, new_timespec, uaddr2, val3)) {
-                Some(result) => result as _,
+                Some(result) => ptr::invalid_mut(result as _),
                 None => ptr::invalid_mut(!0),
             }
         }

--- a/mustang/src/lib.rs
+++ b/mustang/src/lib.rs
@@ -1,4 +1,7 @@
 #![doc = include_str!("../README.md")]
+#![feature(strict_provenance)]
+#![deny(fuzzy_provenance_casts)]
+#![deny(lossy_provenance_casts)]
 
 /// Declare that a program can be compiled and run by `mustang`.
 ///

--- a/origin/src/lib.rs
+++ b/origin/src/lib.rs
@@ -8,6 +8,8 @@
 #![feature(link_llvm_intrinsics)]
 #![feature(atomic_mut_ptr)]
 #![feature(strict_provenance)]
+#![deny(fuzzy_provenance_casts)]
+#![deny(lossy_provenance_casts)]
 #![no_std]
 
 #[cfg(not(feature = "rustc-dep-of-std"))]


### PR DESCRIPTION
Use `#![deny(fuzzy_provenance_casts)]` and `#![deny(lossy_provenance_casts)]`,
which disallow ptr2int and int2ptr casts, and fix a few casts which
remained after #106.