### PR TITLE
Update to rustix 0.35-6-beta.2.

### DIFF
--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 libm = "0.2.1"
-rustix = { version = "0.35.6-alpha.1", default-features = false, features = ["fs", "itoa", "net", "process", "rand", "termios", "thread", "time"] }
+rustix = { version = "0.35.6-beta.2", default-features = false, features = ["fs", "itoa", "net", "param", "process", "rand", "termios", "thread", "time"] }
 memoffset = "0.6"
 realpath-ext = { version = "0.1.0", default-features = false }
 memchr = { version = "2.4.1", default-features = false }

--- a/c-scape/src/fs/access.rs
+++ b/c-scape/src/fs/access.rs
@@ -1,5 +1,5 @@
+use core::ffi::CStr;
 use rustix::fd::BorrowedFd;
-use rustix::ffi::ZStr;
 use rustix::fs::{Access, AtFlags};
 
 use libc::{c_char, c_int};
@@ -24,7 +24,7 @@ unsafe extern "C" fn faccessat(
 
     match convert_res(rustix::fs::accessat(
         BorrowedFd::borrow_raw(fd),
-        ZStr::from_ptr(pathname.cast()),
+        CStr::from_ptr(pathname.cast()),
         Access::from_bits(amode as _).unwrap(),
         AtFlags::from_bits(flags as _).unwrap(),
     )) {

--- a/c-scape/src/fs/chmod.rs
+++ b/c-scape/src/fs/chmod.rs
@@ -1,5 +1,5 @@
+use core::ffi::CStr;
 use rustix::fd::BorrowedFd;
-use rustix::ffi::ZStr;
 use rustix::fs::{cwd, Mode};
 
 use libc::{c_char, c_int, c_uint};
@@ -13,7 +13,7 @@ unsafe extern "C" fn chmod(pathname: *const c_char, mode: c_uint) -> c_int {
     let mode = Mode::from_bits((mode & !libc::S_IFMT) as _).unwrap();
     match convert_res(rustix::fs::chmodat(
         cwd(),
-        ZStr::from_ptr(pathname.cast()),
+        CStr::from_ptr(pathname.cast()),
         mode,
     )) {
         Some(()) => 0,

--- a/c-scape/src/fs/link.rs
+++ b/c-scape/src/fs/link.rs
@@ -1,5 +1,5 @@
+use core::ffi::CStr;
 use rustix::fd::BorrowedFd;
-use rustix::ffi::ZStr;
 use rustix::fs::AtFlags;
 
 use libc::{c_char, c_int};
@@ -26,9 +26,9 @@ unsafe extern "C" fn linkat(
     let flags = AtFlags::from_bits(flags as _).unwrap();
     match convert_res(rustix::fs::linkat(
         BorrowedFd::borrow_raw(olddirfd),
-        ZStr::from_ptr(oldpath.cast()),
+        CStr::from_ptr(oldpath.cast()),
         BorrowedFd::borrow_raw(newdirfd),
-        ZStr::from_ptr(newpath.cast()),
+        CStr::from_ptr(newpath.cast()),
         flags,
     )) {
         Some(()) => 0,

--- a/c-scape/src/fs/mkdir.rs
+++ b/c-scape/src/fs/mkdir.rs
@@ -1,5 +1,5 @@
+use core::ffi::CStr;
 use rustix::fd::BorrowedFd;
-use rustix::ffi::ZStr;
 use rustix::fs::Mode;
 
 use libc::{c_char, c_int};
@@ -20,7 +20,7 @@ unsafe extern "C" fn mkdirat(fd: c_int, pathname: *const c_char, mode: libc::mod
     let mode = Mode::from_bits((mode & !libc::S_IFMT) as _).unwrap();
     match convert_res(rustix::fs::mkdirat(
         BorrowedFd::borrow_raw(fd),
-        ZStr::from_ptr(pathname.cast()),
+        CStr::from_ptr(pathname.cast()),
         mode,
     )) {
         Some(()) => 0,

--- a/c-scape/src/fs/mod.rs
+++ b/c-scape/src/fs/mod.rs
@@ -17,8 +17,8 @@ mod symlink;
 mod sync;
 mod truncate;
 
+use core::ffi::CStr;
 use rustix::fd::BorrowedFd;
-use rustix::ffi::ZStr;
 use rustix::fs::AtFlags;
 
 use core::{convert::TryInto, mem::transmute, ptr::null_mut};
@@ -50,7 +50,7 @@ unsafe extern "C" fn statx(
     let mask = rustix::fs::StatxFlags::from_bits(mask).unwrap();
     match convert_res(rustix::fs::statx(
         BorrowedFd::borrow_raw(dirfd_),
-        ZStr::from_ptr(path.cast()),
+        CStr::from_ptr(path.cast()),
         flags,
         mask,
     )) {

--- a/c-scape/src/fs/open.rs
+++ b/c-scape/src/fs/open.rs
@@ -1,5 +1,5 @@
+use core::ffi::CStr;
 use rustix::fd::{BorrowedFd, IntoRawFd};
-use rustix::ffi::ZStr;
 use rustix::fs::{cwd, Mode, OFlags};
 
 use libc::{c_char, c_int};
@@ -20,7 +20,7 @@ macro_rules! openat_impl {
         };
         match convert_res(rustix::fs::openat(
             &$fd,
-            ZStr::from_ptr($pathname.cast()),
+            CStr::from_ptr($pathname.cast()),
             flags,
             mode,
         )) {

--- a/c-scape/src/fs/opendir.rs
+++ b/c-scape/src/fs/opendir.rs
@@ -1,5 +1,5 @@
+use core::ffi::CStr;
 use rustix::fd::{BorrowedFd, FromRawFd, IntoRawFd};
-use rustix::ffi::ZStr;
 use rustix::fs::{cwd, Mode, OFlags};
 use rustix::io::OwnedFd;
 
@@ -20,7 +20,7 @@ unsafe extern "C" fn opendir(pathname: *const c_char) -> *mut c_void {
 
     match convert_res(rustix::fs::openat(
         cwd(),
-        ZStr::from_ptr(pathname.cast()),
+        CStr::from_ptr(pathname.cast()),
         OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
         Mode::empty(),
     )) {

--- a/c-scape/src/fs/readlink.rs
+++ b/c-scape/src/fs/readlink.rs
@@ -1,5 +1,5 @@
+use core::ffi::CStr;
 use rustix::fd::BorrowedFd;
-use rustix::ffi::ZStr;
 
 use libc::{c_char, c_int};
 
@@ -23,7 +23,7 @@ unsafe extern "C" fn readlinkat(
 
     let path = match convert_res(rustix::fs::readlinkat(
         BorrowedFd::borrow_raw(fd),
-        ZStr::from_ptr(pathname.cast()),
+        CStr::from_ptr(pathname.cast()),
         Vec::new(),
     )) {
         Some(path) => path,

--- a/c-scape/src/fs/realpath.rs
+++ b/c-scape/src/fs/realpath.rs
@@ -1,4 +1,4 @@
-use rustix::ffi::ZStr;
+use core::ffi::CStr;
 
 use core::ptr::null_mut;
 use errno::{set_errno, Errno};
@@ -12,7 +12,7 @@ unsafe extern "C" fn realpath(path: *const c_char, resolved_path: *mut c_char) -
 
     let mut buf = [0; libc::PATH_MAX as usize];
     match realpath_ext::realpath_raw(
-        ZStr::from_ptr(path.cast()).to_bytes(),
+        CStr::from_ptr(path.cast()).to_bytes(),
         &mut buf,
         realpath_ext::RealpathFlags::empty(),
     ) {

--- a/c-scape/src/fs/remove.rs
+++ b/c-scape/src/fs/remove.rs
@@ -1,5 +1,5 @@
+use core::ffi::CStr;
 use rustix::fd::BorrowedFd;
-use rustix::ffi::ZStr;
 use rustix::fs::AtFlags;
 
 use libc::{c_char, c_int};
@@ -28,7 +28,7 @@ unsafe extern "C" fn unlinkat(fd: c_int, pathname: *const c_char, flags: c_int) 
     let flags = AtFlags::from_bits(flags as _).unwrap();
     match convert_res(rustix::fs::unlinkat(
         &fd,
-        ZStr::from_ptr(pathname.cast()),
+        CStr::from_ptr(pathname.cast()),
         flags,
     )) {
         Some(()) => 0,

--- a/c-scape/src/fs/rename.rs
+++ b/c-scape/src/fs/rename.rs
@@ -1,5 +1,5 @@
+use core::ffi::CStr;
 use rustix::fd::BorrowedFd;
-use rustix::ffi::ZStr;
 
 use libc::{c_char, c_int};
 
@@ -23,9 +23,9 @@ unsafe extern "C" fn renameat(
 
     match convert_res(rustix::fs::renameat(
         BorrowedFd::borrow_raw(old_fd),
-        ZStr::from_ptr(old.cast()),
+        CStr::from_ptr(old.cast()),
         BorrowedFd::borrow_raw(new_fd),
-        ZStr::from_ptr(new.cast()),
+        CStr::from_ptr(new.cast()),
     )) {
         Some(()) => 0,
         None => -1,

--- a/c-scape/src/fs/stat.rs
+++ b/c-scape/src/fs/stat.rs
@@ -1,5 +1,5 @@
+use core::ffi::CStr;
 use rustix::fd::BorrowedFd;
-use rustix::ffi::ZStr;
 use rustix::fs::AtFlags;
 
 use core::convert::TryInto;
@@ -72,7 +72,7 @@ unsafe extern "C" fn fstatat(
     let flags = AtFlags::from_bits(flags as _).unwrap();
     let rustix_stat = match convert_res(rustix::fs::statat(
         BorrowedFd::borrow_raw(fd),
-        ZStr::from_ptr(pathname.cast()),
+        CStr::from_ptr(pathname.cast()),
         flags,
     )) {
         Some(r) => r,
@@ -105,7 +105,7 @@ unsafe extern "C" fn fstatat64(
     let flags = AtFlags::from_bits(flags as _).unwrap();
     match convert_res(rustix::fs::statat(
         BorrowedFd::borrow_raw(fd),
-        ZStr::from_ptr(pathname.cast()),
+        CStr::from_ptr(pathname.cast()),
         flags,
     )) {
         Some(r) => {

--- a/c-scape/src/fs/symlink.rs
+++ b/c-scape/src/fs/symlink.rs
@@ -1,5 +1,5 @@
+use core::ffi::CStr;
 use rustix::fd::BorrowedFd;
-use rustix::ffi::ZStr;
 
 use libc::{c_char, c_int};
 
@@ -21,9 +21,9 @@ unsafe extern "C" fn symlinkat(
     libc!(libc::symlinkat(target, linkdirfd, linkpath));
 
     match convert_res(rustix::fs::symlinkat(
-        ZStr::from_ptr(target.cast()),
+        CStr::from_ptr(target.cast()),
         BorrowedFd::borrow_raw(linkdirfd),
-        ZStr::from_ptr(linkpath.cast()),
+        CStr::from_ptr(linkpath.cast()),
     )) {
         Some(()) => 0,
         None => -1,

--- a/c-scape/src/io/dup.rs
+++ b/c-scape/src/io/dup.rs
@@ -18,8 +18,8 @@ unsafe extern "C" fn dup(fd: c_int) -> c_int {
 unsafe extern "C" fn dup2(fd: c_int, to: c_int) -> c_int {
     libc!(libc::dup2(fd, to));
 
-    let to = OwnedFd::from_raw_fd(to).into();
-    match convert_res(rustix::io::dup2(BorrowedFd::borrow_raw(fd), &to)) {
+    let mut to = OwnedFd::from_raw_fd(to).into();
+    match convert_res(rustix::io::dup2(BorrowedFd::borrow_raw(fd), &mut to)) {
         Some(()) => OwnedFd::from(to).into_raw_fd(),
         None => -1,
     }

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -171,7 +171,7 @@ unsafe extern "C" fn getauxval(type_: c_ulong) -> *mut c_void {
 unsafe extern "C" fn __getauxval(type_: c_ulong) -> *mut c_void {
     //libc!(ptr::from_exposed_addr(libc::__getauxval(type_) as _));
     match type_ {
-        libc::AT_HWCAP => ptr::invalid_mut(rustix::process::linux_hwcap().0),
+        libc::AT_HWCAP => ptr::invalid_mut(rustix::param::linux_hwcap().0),
         _ => unimplemented!("unrecognized __getauxval {}", type_),
     }
 }

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -8,6 +8,7 @@
 #![feature(atomic_mut_ptr)] // for `RawMutex`
 #![feature(strict_provenance)]
 #![feature(sync_unsafe_cell)]
+#![feature(core_c_str)] // for `core::ffi::CStr`
 #![deny(fuzzy_provenance_casts)]
 #![deny(lossy_provenance_casts)]
 #![feature(try_blocks)]
@@ -48,7 +49,7 @@ use core::slice;
 use errno::{set_errno, Errno};
 use error_str::error_str;
 use libc::{c_char, c_int, c_long, c_ulong};
-use rustix::ffi::ZStr;
+use rustix::ffi::CStr;
 use rustix::fs::{AtFlags, Mode, OFlags};
 
 // fs
@@ -122,7 +123,7 @@ unsafe extern "C" fn getrandom(buf: *mut c_void, buflen: usize, flags: u32) -> i
     if buflen == 0 {
         return 0;
     }
-    let flags = rustix::rand::GetRandomFlags::from_bits(flags).unwrap();
+    let flags = rustix::rand::GetRandomFlags::from_bits(flags & !0x4).unwrap();
     match convert_res(rustix::rand::getrandom(
         slice::from_raw_parts_mut(buf.cast::<u8>(), buflen),
         flags,
@@ -145,7 +146,7 @@ unsafe extern "C" fn sysconf(name: c_int) -> c_long {
     libc!(libc::sysconf(name));
 
     match name {
-        libc::_SC_PAGESIZE => rustix::process::page_size() as _,
+        libc::_SC_PAGESIZE => rustix::param::page_size() as _,
         #[cfg(not(target_os = "wasi"))]
         libc::_SC_GETPW_R_SIZE_MAX => -1,
         // TODO: Oddly, only ever one processor seems to be online.
@@ -213,34 +214,34 @@ unsafe extern "C" fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c
         // `std` uses `dlsym` to dynamically detect feature availability; recognize
         // functions it asks for.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        if ZStr::from_ptr(symbol.cast()).to_bytes() == b"statx" {
+        if CStr::from_ptr(symbol.cast()).to_bytes() == b"statx" {
             todo!()
             // return statx as *mut c_void;
         }
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        if ZStr::from_ptr(symbol.cast()).to_bytes() == b"getrandom" {
+        if CStr::from_ptr(symbol.cast()).to_bytes() == b"getrandom" {
             return getrandom as *mut c_void;
         }
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        if ZStr::from_ptr(symbol.cast()).to_bytes() == b"copy_file_range" {
+        if CStr::from_ptr(symbol.cast()).to_bytes() == b"copy_file_range" {
             // return copy_file_range as *mut c_void;
             todo!()
         }
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        if ZStr::from_ptr(symbol.cast()).to_bytes() == b"clone3" {
+        if CStr::from_ptr(symbol.cast()).to_bytes() == b"clone3" {
             // Let's just say we don't support this for now.
             return null_mut();
         }
-        if ZStr::from_ptr(symbol.cast()).to_bytes() == b"__pthread_get_minstack" {
+        if CStr::from_ptr(symbol.cast()).to_bytes() == b"__pthread_get_minstack" {
             // Let's just say we don't support this for now.
             return null_mut();
         }
         #[cfg(target_env = "gnu")]
-        if ZStr::from_ptr(symbol.cast()).to_bytes() == b"gnu_get_libc_version" {
+        if CStr::from_ptr(symbol.cast()).to_bytes() == b"gnu_get_libc_version" {
             return gnu_get_libc_version as *mut c_void;
         }
     }
-    unimplemented!("dlsym({:?})", ZStr::from_ptr(symbol.cast()))
+    unimplemented!("dlsym({:?})", CStr::from_ptr(symbol.cast()))
 }
 
 #[no_mangle]
@@ -309,7 +310,7 @@ unsafe extern "C" fn prctl(
     libc!(libc::prctl(option, arg2, _arg3, _arg4, _arg5));
     match option {
         libc::PR_SET_NAME => {
-            match convert_res(rustix::runtime::set_thread_name(ZStr::from_ptr(
+            match convert_res(rustix::runtime::set_thread_name(CStr::from_ptr(
                 arg2 as *const _,
             ))) {
                 Some(()) => 0,
@@ -617,18 +618,18 @@ unsafe extern "C" fn execvp(file: *const c_char, args: *const *const c_char) -> 
 
     let cwd = rustix::fs::cwd();
 
-    let file = ZStr::from_ptr(file);
+    let file = CStr::from_ptr(file);
     if file.to_bytes().contains(&b'/') {
         let err = rustix::runtime::execve(file, args.cast(), environ.cast());
         set_errno(Errno(err.raw_os_error()));
         return -1;
     }
 
-    let path = _getenv(rustix::zstr!("PATH"));
+    let path = _getenv(rustix::cstr!("PATH"));
     let path = if path.is_null() {
-        rustix::zstr!("/bin:/usr/bin")
+        rustix::cstr!("/bin:/usr/bin")
     } else {
-        ZStr::from_ptr(path)
+        CStr::from_ptr(path)
     };
 
     let mut access_error = false;
@@ -665,10 +666,10 @@ unsafe extern "C" fn execvp(file: *const c_char, args: *const *const c_char) -> 
                 let mut buf = [0_u8; PREFIX_LEN + 20 + 1];
                 buf[..PREFIX_LEN].copy_from_slice(PREFIX);
                 let fd_dec = rustix::path::DecInt::from_fd(&fd);
-                let fd_bytes = fd_dec.as_z_str().to_bytes_with_nul();
+                let fd_bytes = fd_dec.as_c_str().to_bytes_with_nul();
                 buf[PREFIX_LEN..PREFIX_LEN + fd_bytes.len()].copy_from_slice(fd_bytes);
                 error = rustix::runtime::execve(
-                    ZStr::from_bytes_with_nul_unchecked(&buf),
+                    CStr::from_bytes_with_nul_unchecked(&buf),
                     args.cast(),
                     environ.cast(),
                 );
@@ -746,11 +747,11 @@ unsafe extern "C" fn __sigsetjmp() {
 #[no_mangle]
 unsafe extern "C" fn getenv(key: *const c_char) -> *mut c_char {
     libc!(libc::getenv(key));
-    let key = ZStr::from_ptr(key.cast());
+    let key = CStr::from_ptr(key.cast());
     _getenv(key)
 }
 
-unsafe fn _getenv(key: &ZStr) -> *mut c_char {
+unsafe fn _getenv(key: &CStr) -> *mut c_char {
     let mut ptr = environ;
     loop {
         let env = *ptr;

--- a/c-scape/src/net/mod.rs
+++ b/c-scape/src/net/mod.rs
@@ -2,6 +2,7 @@
 use alloc::string::ToString;
 use core::convert::TryInto;
 use core::ffi::c_void;
+use core::ffi::CStr;
 #[cfg(not(target_os = "wasi"))]
 use core::mem::{size_of, zeroed};
 use core::ptr::null_mut;
@@ -9,7 +10,6 @@ use core::slice;
 use errno::{set_errno, Errno};
 use libc::{c_char, c_int, c_uint};
 use rustix::fd::{BorrowedFd, IntoRawFd};
-use rustix::ffi::ZStr;
 #[cfg(feature = "net")]
 use rustix::net::{
     AcceptFlags, AddressFamily, Ipv4Addr, Ipv6Addr, Protocol, RecvFlags, SendFlags, Shutdown,
@@ -469,7 +469,7 @@ unsafe extern "C" fn getaddrinfo(
         assert!(hints.ai_next.is_null(), "GAI next hint not supported yet");
     }
 
-    let host = match ZStr::from_ptr(node.cast()).to_str() {
+    let host = match CStr::from_ptr(node.cast()).to_str() {
         Ok(host) => host,
         Err(_) => {
             set_errno(Errno(libc::EILSEQ));

--- a/c-scape/src/process/chdir.rs
+++ b/c-scape/src/process/chdir.rs
@@ -1,5 +1,5 @@
+use core::ffi::CStr;
 use rustix::fd::BorrowedFd;
-use rustix::ffi::ZStr;
 
 use libc::{c_char, c_int};
 
@@ -9,7 +9,7 @@ use crate::convert_res;
 unsafe extern "C" fn chdir(path: *const c_char) -> c_int {
     libc!(libc::chdir(path));
 
-    let path = ZStr::from_ptr(path.cast());
+    let path = CStr::from_ptr(path.cast());
     match convert_res(rustix::process::chdir(path)) {
         Some(()) => 0,
         None => -1,

--- a/origin/Cargo.toml
+++ b/origin/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 linux-raw-sys = { version = "0.0.46", default-features = false, features = ["general", "no_std"] }
-rustix = { version = "0.35.6-alpha.0", default-features = false, features = ["mm", "thread", "runtime", "process"] }
+rustix = { version = "0.35.6-beta.2", default-features = false, features = ["mm", "thread", "runtime", "param", "process"] }
 bitflags = "1.3.0"
 memoffset = { version = "0.6.4", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }

--- a/origin/src/program.rs
+++ b/origin/src/program.rs
@@ -74,7 +74,7 @@ pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
     // Explicitly initialize `rustix`. On non-mustang platforms it uses a
     // .init_array hook to initialize itself automatically, but for mustang, we
     // do it manually so that we can control the initialization order.
-    rustix::process::init(envp);
+    rustix::param::init(envp);
 
     // Initialize the main thread.
     #[cfg(feature = "threads")]

--- a/origin/src/threads.rs
+++ b/origin/src/threads.rs
@@ -16,8 +16,11 @@ use core::sync::atomic::{AtomicU32, AtomicU8};
 use memoffset::offset_of;
 use rustix::io;
 #[cfg(target_vendor = "mustang")]
-use rustix::process::{getrlimit, linux_execfn, Resource};
-use rustix::process::{page_size, Pid, RawNonZeroPid};
+use rustix::param::linux_execfn;
+use rustix::param::page_size;
+#[cfg(target_vendor = "mustang")]
+use rustix::process::{getrlimit, Resource};
+use rustix::process::{Pid, RawNonZeroPid};
 use rustix::runtime::{set_tid_address, StartupTlsInfo};
 use rustix::thread::gettid;
 #[cfg(feature = "raw_dtors")]


### PR DESCRIPTION
 - `ZStr` is renamed back to `CStr`.
 - `page_size` and `init` have moved to `param`.
 - `dup2`'s second argument is now `&mut OwnedFd`.