### PR TITLE
Fix and re-enable x86 support.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       QEMU_BUILD_VERSION: 6.1.0
     strategy:
       matrix:
-        build: [ubuntu, ubuntu-18.04, aarch64-linux, riscv64-linux]
+        build: [ubuntu, ubuntu-18.04, i686-linux, aarch64-linux, riscv64-linux]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -38,6 +38,15 @@ jobs:
             rust: nightly
             host_target: x86_64-unknown-linux-gnu
             mustang_target: x86_64-mustang-linux-gnu
+          - build: i686-linux
+            os: ubuntu-latest
+            rust: nightly
+            target: i686-unknown-linux-gnu
+            gcc_package: gcc-i686-linux-gnu
+            gcc: i686-linux-gnu-gcc
+            libc_package: libc-dev-i386-cross
+            host_target: i686-unknown-linux-gnu
+            mustang_target: i686-mustang-linux-gnu
           - build: aarch64-linux
             os: ubuntu-latest
             rust: nightly

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This also isn't about building a complete libc. It currently includes some
 things with libc-compatible interfaces, just enough to allow it to slide in
 underneath `std`, however even this may not always be necessary. We'll see.
 
-Mustang currently runs on Rust Nightly on Linux on x86-64, aarch64, and
+Mustang currently runs on Rust Nightly on Linux on x86-64, x86, aarch64, and
 riscv64. It aims to support all Linux versions [supported by Rust], though
 at this time it's only tested on relatively recent versions.
 

--- a/c-scape/src/threads/mod.rs
+++ b/c-scape/src/threads/mod.rs
@@ -91,8 +91,6 @@ struct PthreadRwlockT {
     pad2: usize,
     pad3: usize,
     pad4: usize,
-    #[cfg(target_arch = "x86")]
-    pad5: usize,
 }
 libc_type!(PthreadRwlockT, pthread_rwlock_t);
 


### PR DESCRIPTION
The switch from parking_lot to futex-based locks significantly
simplifies the interaction between locking and allocation, so
let's try re-enabling the x86 target.