### PR TITLE
Make all functions in `c-scape` non-`pub`.

### DIFF
--- a/c-scape/src/fs/realpath.rs
+++ b/c-scape/src/fs/realpath.rs
@@ -2,9 +2,7 @@ use core::ffi::CStr;
 
 use core::ptr::null_mut;
 use errno::{set_errno, Errno};
-use libc::{c_char, c_void};
-
-use crate::{malloc, memcpy};
+use libc::{c_char, c_void, malloc, memcpy};
 
 #[no_mangle]
 unsafe extern "C" fn realpath(path: *const c_char, resolved_path: *mut c_char) -> *mut c_char {

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -61,15 +61,11 @@ mod io;
 // malloc
 mod malloc;
 
-pub use malloc::*;
-
 // math
 mod math;
 
 // mem
 mod mem;
-
-pub use mem::*;
 
 // mmap
 #[cfg(not(target_os = "wasi"))]

--- a/c-scape/src/malloc/mod.rs
+++ b/c-scape/src/malloc/mod.rs
@@ -3,9 +3,7 @@ use core::{
     ptr,
 };
 use errno::{set_errno, Errno};
-use libc::{c_int, c_void};
-
-use crate::{memcpy, memset};
+use libc::{c_int, c_void, memcpy, memset};
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
@@ -68,7 +66,7 @@ unsafe fn tagged_dealloc(ptr: *mut u8) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn malloc(size: usize) -> *mut c_void {
+unsafe extern "C" fn malloc(size: usize) -> *mut c_void {
     libc!(libc::malloc(size));
 
     // TODO: Add `max_align_t` for riscv64 to upstream libc.
@@ -86,7 +84,7 @@ pub unsafe extern "C" fn malloc(size: usize) -> *mut c_void {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn realloc(old: *mut c_void, size: usize) -> *mut c_void {
+unsafe extern "C" fn realloc(old: *mut c_void, size: usize) -> *mut c_void {
     libc!(libc::realloc(old, size));
 
     if old.is_null() {
@@ -106,7 +104,7 @@ pub unsafe extern "C" fn realloc(old: *mut c_void, size: usize) -> *mut c_void {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn calloc(nmemb: usize, size: usize) -> *mut c_void {
+unsafe extern "C" fn calloc(nmemb: usize, size: usize) -> *mut c_void {
     libc!(libc::calloc(nmemb, size));
 
     let product = match nmemb.checked_mul(size) {
@@ -140,7 +138,7 @@ unsafe extern "C" fn posix_memalign(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn free(ptr: *mut c_void) {
+unsafe extern "C" fn free(ptr: *mut c_void) {
     libc!(libc::free(ptr));
 
     if ptr.is_null() {

--- a/c-scape/src/mem/bstring.rs
+++ b/c-scape/src/mem/bstring.rs
@@ -3,7 +3,7 @@ use libc::{c_int, c_void};
 
 // Obsolescent
 #[no_mangle]
-pub unsafe extern "C" fn bcmp(a: *const c_void, b: *const c_void, len: usize) -> c_int {
+unsafe extern "C" fn bcmp(a: *const c_void, b: *const c_void, len: usize) -> c_int {
     // `bcmp` is just an alias for `memcmp`.
     libc!(libc::memcmp(a, b, len));
 
@@ -11,7 +11,7 @@ pub unsafe extern "C" fn bcmp(a: *const c_void, b: *const c_void, len: usize) ->
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn memchr(s: *const c_void, c: c_int, len: usize) -> *mut c_void {
+unsafe extern "C" fn memchr(s: *const c_void, c: c_int, len: usize) -> *mut c_void {
     libc!(libc::memchr(s, c, len));
 
     let slice: &[u8] = slice::from_raw_parts(s.cast(), len);
@@ -23,7 +23,7 @@ pub unsafe extern "C" fn memchr(s: *const c_void, c: c_int, len: usize) -> *mut 
 
 // Extension: GNU
 #[no_mangle]
-pub unsafe extern "C" fn memrchr(s: *const c_void, c: c_int, len: usize) -> *mut c_void {
+unsafe extern "C" fn memrchr(s: *const c_void, c: c_int, len: usize) -> *mut c_void {
     libc!(libc::memrchr(s, c, len));
 
     let slice: &[u8] = slice::from_raw_parts(s.cast(), len);
@@ -34,28 +34,28 @@ pub unsafe extern "C" fn memrchr(s: *const c_void, c: c_int, len: usize) -> *mut
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn memcmp(a: *const c_void, b: *const c_void, len: usize) -> c_int {
+unsafe extern "C" fn memcmp(a: *const c_void, b: *const c_void, len: usize) -> c_int {
     libc!(libc::memcmp(a, b, len));
 
     compiler_builtins::mem::memcmp(a.cast(), b.cast(), len)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn memcpy(dst: *mut c_void, src: *const c_void, len: usize) -> *mut c_void {
+unsafe extern "C" fn memcpy(dst: *mut c_void, src: *const c_void, len: usize) -> *mut c_void {
     libc!(libc::memcpy(dst, src, len));
 
     compiler_builtins::mem::memcpy(dst.cast(), src.cast(), len).cast()
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn memmove(dst: *mut c_void, src: *const c_void, len: usize) -> *mut c_void {
+unsafe extern "C" fn memmove(dst: *mut c_void, src: *const c_void, len: usize) -> *mut c_void {
     libc!(libc::memmove(dst, src, len));
 
     compiler_builtins::mem::memmove(dst.cast(), src.cast(), len).cast()
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn memset(dst: *mut c_void, fill: c_int, len: usize) -> *mut c_void {
+unsafe extern "C" fn memset(dst: *mut c_void, fill: c_int, len: usize) -> *mut c_void {
     libc!(libc::memset(dst, fill, len));
 
     compiler_builtins::mem::memset(dst.cast(), fill, len).cast()

--- a/c-scape/src/mem/mod.rs
+++ b/c-scape/src/mem/mod.rs
@@ -1,4 +1,2 @@
 mod bstring;
 mod string;
-
-pub use bstring::*;

--- a/c-scape/src/mem/string.rs
+++ b/c-scape/src/mem/string.rs
@@ -1,8 +1,6 @@
 use core::cell::SyncUnsafeCell;
 use core::ptr;
-use libc::{c_char, c_int, c_schar};
-
-use crate::{malloc, memcpy};
+use libc::{c_char, c_int, c_schar, malloc, memcpy};
 
 const NUL: c_char = 0;
 

--- a/c-scape/src/net/mod.rs
+++ b/c-scape/src/net/mod.rs
@@ -576,7 +576,7 @@ unsafe extern "C" fn gethostname(name: *mut c_char, len: usize) -> c_int {
         set_errno(Errno(libc::ENAMETOOLONG));
         return -1;
     }
-    crate::memcpy(
+    libc::memcpy(
         name.cast(),
         nodename.to_bytes().as_ptr().cast(),
         nodename.to_bytes().len(),

--- a/c-scape/src/process/getcwd.rs
+++ b/c-scape/src/process/getcwd.rs
@@ -1,9 +1,9 @@
 use alloc::vec::Vec;
 use core::ptr::null_mut;
 use errno::{set_errno, Errno};
-use libc::c_char;
+use libc::{c_char, memcpy};
 
-use crate::{convert_res, memcpy};
+use crate::convert_res;
 
 #[no_mangle]
 unsafe extern "C" fn getcwd(buf: *mut c_char, len: usize) -> *mut c_char {


### PR DESCRIPTION
C-scape implements a `libc`-crate-compatible ABI. We use the `libc` crate
to provide the public interface to it, and just substitute in c-scape at
link time. Consequently, c-scape's functions don't need to be `pub`. And
it's cleaner if they aren't, because this ensures that all users use
c-scape consistently.