### PR TITLE
Fix warnings.

### DIFF
--- a/c-scape/src/malloc/mod.rs
+++ b/c-scape/src/malloc/mod.rs
@@ -1,7 +1,6 @@
-use core::{
-    mem::{align_of, size_of},
-    ptr,
-};
+#[cfg(not(target_arch = "riscv64"))]
+use core::mem::align_of;
+use core::{mem::size_of, ptr};
 use errno::{set_errno, Errno};
 use libc::{c_int, c_void};
 

--- a/origin/src/threads.rs
+++ b/origin/src/threads.rs
@@ -335,6 +335,7 @@ unsafe fn exit_thread() -> ! {
     if let Err(e) = state {
         // The thread was detached. Prepare to free the memory. First read out
         // all the fields that we'll need before freeing it.
+        #[cfg(feature = "log")]
         let current_thread_id = (*current).thread_id.load(SeqCst);
         let current_map_size = (*current).map_size;
         let current_stack_addr = (*current).stack_addr;

--- a/specs/aarch64-mustang-linux-gnu.json
+++ b/specs/aarch64-mustang-linux-gnu.json
@@ -5,7 +5,6 @@
   "dynamic-linking": false,
   "env": "gnu",
   "executables": true,
-  "has-elf-tls": true,
   "has-thread-local": true,
   "has-rpath": true,
   "llvm-target": "aarch64-unknown-linux-gnu",

--- a/specs/armv5te-mustang-linux-gnueabi.json
+++ b/specs/armv5te-mustang-linux-gnueabi.json
@@ -7,7 +7,6 @@
   "env": "gnu",
   "executables": true,
   "features": "+soft-float,+strict-align",
-  "has-elf-tls": true,
   "has-thread-local": true,
   "has-rpath": true,
   "has-thumb-interworking": true,

--- a/specs/i686-mustang-linux-gnu.json
+++ b/specs/i686-mustang-linux-gnu.json
@@ -6,7 +6,6 @@
   "dynamic-linking": false,
   "env": "gnu",
   "executables": true,
-  "has-elf-tls": true,
   "has-thread-local": true,
   "has-rpath": true,
   "llvm-target": "i686-unknown-linux-gnu",

--- a/specs/riscv64gc-mustang-linux-gnu.json
+++ b/specs/riscv64gc-mustang-linux-gnu.json
@@ -8,7 +8,6 @@
   "env": "gnu",
   "executables": true,
   "features": "+m,+a,+f,+d,+c",
-  "has-elf-tls": true,
   "has-thread-local": true,
   "has-rpath": true,
   "llvm-abiname": "lp64d",

--- a/specs/x86_64-mustang-linux-gnu.json
+++ b/specs/x86_64-mustang-linux-gnu.json
@@ -6,7 +6,6 @@
   "dynamic-linking": false,
   "env": "gnu",
   "executables": true,
-  "has-elf-tls": true,
   "has-thread-local": true,
   "has-rpath": true,
   "llvm-target": "x86_64-unknown-linux-gnu",

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -58,9 +58,6 @@ fn test_example(name: &str, features: &str, stdout: &str, stderr: &str) {
         .arg(name);
     let output = command.output().unwrap();
 
-    // FIXME: Re-enable this once we no longer get "warning: target json file
-    // contains unused fields: has-thread-local" warnings.
-    /*
     assert_eq_str!(
         stderr.as_bytes(),
         &output.stderr,
@@ -68,7 +65,6 @@ fn test_example(name: &str, features: &str, stdout: &str, stderr: &str) {
         name,
         output
     );
-    */
 
     assert_eq_str!(
         stdout.as_bytes(),


### PR DESCRIPTION
Fix an unused-variable warning in origin/src/threads.rs in release builds.

And remove the has-elf-tls keys from the target descriptions, which
are no longer needed. And re-enable stderr checking in the examples
test now that we no longer get warnings.