### PR TITLE
Update some tests to the latest upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Rust programs written entirely in Rust"
 documentation = "https://docs.rs/mustang"
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 repository = "https://github.com/sunfishcode/mustang"
-edition = "2018"
+edition = "2021"
 exclude = ["/.github"]
 publish = false
 

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -8,7 +8,7 @@ description = "A libc implementation in Rust"
 documentation = "https://docs.rs/c-scape"
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 repository = "https://github.com/sunfishcode/mustang"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 libm = "0.2.1"

--- a/c-scape/aarch64_outline_atomics/aarch64_outline_atomics/Cargo.toml
+++ b/c-scape/aarch64_outline_atomics/aarch64_outline_atomics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aarch64_outline_atomics"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [workspace]

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -847,7 +847,10 @@ unsafe extern "C" fn __cxa_atexit(
     unsafe impl Send for SendSync {}
     unsafe impl Sync for SendSync {}
     let arg = SendSync(arg);
-    origin::at_exit(Box::new(move || func(arg.0)));
+    origin::at_exit(Box::new(move || {
+        let arg: SendSync = arg;
+        func(arg.0);
+    }));
     0
 }
 

--- a/mustang/Cargo.toml
+++ b/mustang/Cargo.toml
@@ -8,7 +8,7 @@ description = "Rust programs written entirely in Rust"
 documentation = "https://docs.rs/mustang"
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 repository = "https://github.com/sunfishcode/mustang"
-edition = "2018"
+edition = "2021"
 
 [build-dependencies]
 # Enable the cc dependency to build the empty `libc.a` and similar libraries

--- a/origin/Cargo.toml
+++ b/origin/Cargo.toml
@@ -8,7 +8,7 @@ description = "Program startup and thread support written in Rust"
 documentation = "https://docs.rs/origin"
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 repository = "https://github.com/sunfishcode/mustang"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 linux-raw-sys = { version = "0.0.46", default-features = false, features = ["general", "no_std"] }

--- a/tests/lazy.rs
+++ b/tests/lazy.rs
@@ -132,7 +132,6 @@ fn clone() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn get_or_try_init() {
     let cell: OnceLock<String> = OnceLock::new();
     assert!(cell.get().is_none());
@@ -258,7 +257,6 @@ fn static_sync_lazy_via_fn() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn sync_lazy_poisoning() {
     let x: LazyLock<String> = LazyLock::new(|| panic!("kaboom"));
     for _ in 0..2 {

--- a/tests/lazy.rs
+++ b/tests/lazy.rs
@@ -132,6 +132,7 @@ fn clone() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn get_or_try_init() {
     let cell: OnceLock<String> = OnceLock::new();
     assert!(cell.get().is_none());
@@ -257,6 +258,7 @@ fn static_sync_lazy_via_fn() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn sync_lazy_poisoning() {
     let x: LazyLock<String> = LazyLock::new(|| panic!("kaboom"));
     for _ in 0..2 {

--- a/tests/sync-barrier.rs
+++ b/tests/sync-barrier.rs
@@ -4,8 +4,11 @@
 
 mustang::can_run_this!();
 
+#[cfg(feature = "pthread_cond")]
 use std::sync::mpsc::{channel, TryRecvError};
+#[cfg(feature = "pthread_cond")]
 use std::sync::{Arc, Barrier};
+#[cfg(feature = "pthread_cond")]
 use std::thread;
 
 #[cfg(feature = "pthread_cond")]

--- a/tests/sync-mpsc.rs
+++ b/tests/sync-mpsc.rs
@@ -242,6 +242,7 @@ fn oneshot_single_thread_send_port_close() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn oneshot_single_thread_recv_chan_close() {
     // Receiving on a closed chan will panic
     let res = thread::spawn(move || {
@@ -323,6 +324,7 @@ fn oneshot_multi_task_recv_then_send() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn oneshot_multi_task_recv_then_close() {
     let (tx, rx) = channel::<Box<i32>>();
     let _t = thread::spawn(move || {
@@ -348,6 +350,7 @@ fn oneshot_multi_thread_close_stress() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn oneshot_multi_thread_send_close_stress() {
     for _ in 0..stress_factor() {
         let (tx, rx) = channel::<i32>();
@@ -362,6 +365,7 @@ fn oneshot_multi_thread_send_close_stress() {
 }
 
 #[test]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn oneshot_multi_thread_recv_close_stress() {
     for _ in 0..stress_factor() {
         let (tx, rx) = channel::<i32>();

--- a/tests/sync-mpsc.rs
+++ b/tests/sync-mpsc.rs
@@ -242,7 +242,6 @@ fn oneshot_single_thread_send_port_close() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn oneshot_single_thread_recv_chan_close() {
     // Receiving on a closed chan will panic
     let res = thread::spawn(move || {
@@ -324,7 +323,6 @@ fn oneshot_multi_task_recv_then_send() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn oneshot_multi_task_recv_then_close() {
     let (tx, rx) = channel::<Box<i32>>();
     let _t = thread::spawn(move || {
@@ -350,7 +348,6 @@ fn oneshot_multi_thread_close_stress() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn oneshot_multi_thread_send_close_stress() {
     for _ in 0..stress_factor() {
         let (tx, rx) = channel::<i32>();
@@ -365,7 +362,6 @@ fn oneshot_multi_thread_send_close_stress() {
 }
 
 #[test]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault spuriously
 fn oneshot_multi_thread_recv_close_stress() {
     for _ in 0..stress_factor() {
         let (tx, rx) = channel::<i32>();

--- a/tests/sync-mutex.rs
+++ b/tests/sync-mutex.rs
@@ -6,7 +6,9 @@ mustang::can_run_this!();
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::channel;
-use std::sync::{Arc, Condvar, Mutex};
+#[cfg(feature = "pthread_cond")]
+use std::sync::Condvar;
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 #[cfg(feature = "pthread_cond")]

--- a/tests/sync-mutex.rs
+++ b/tests/sync-mutex.rs
@@ -1,6 +1,6 @@
 //! The following is derived from Rust's
-//! library/std/src/sync/mutex.rs at revision
-//! 497ee321af3b8496eaccd7af7b437f18bab81abf.
+//! library/std/src/sync/mutex/tests.rs at revision
+//! 72a25d05bf1a4b155d74139ef700ff93af6d8e22.
 
 mustang::can_run_this!();
 
@@ -23,7 +23,6 @@ fn smoke() {
 }
 
 #[test]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn lots_and_lots() {
     const J: u32 = 1000;
     const K: u32 = 3;
@@ -91,7 +90,6 @@ fn test_into_inner_drop() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn test_into_inner_poison() {
     let m = Arc::new(Mutex::new(NonCopy(10)));
     let m2 = m.clone();
@@ -104,7 +102,7 @@ fn test_into_inner_poison() {
     assert!(m.is_poisoned());
     match Arc::try_unwrap(m).unwrap().into_inner() {
         Err(e) => assert_eq!(e.into_inner(), NonCopy(10)),
-        Ok(x) => panic!("into_inner of poisoned Mutex is Ok: {:?}", x),
+        Ok(x) => panic!("into_inner of poisoned Mutex is Ok: {x:?}"),
     }
 }
 
@@ -117,7 +115,6 @@ fn test_get_mut() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn test_get_mut_poison() {
     let m = Arc::new(Mutex::new(NonCopy(10)));
     let m2 = m.clone();
@@ -130,7 +127,7 @@ fn test_get_mut_poison() {
     assert!(m.is_poisoned());
     match Arc::try_unwrap(m).unwrap().get_mut() {
         Err(e) => assert_eq!(*e.into_inner(), NonCopy(10)),
-        Ok(x) => panic!("get_mut of poisoned Mutex is Ok: {:?}", x),
+        Ok(x) => panic!("get_mut of poisoned Mutex is Ok: {x:?}"),
     }
 }
 
@@ -190,7 +187,6 @@ fn test_arc_condvar_poison() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn test_mutex_arc_poison() {
     let arc = Arc::new(Mutex::new(1));
     assert!(!arc.is_poisoned());
@@ -222,7 +218,6 @@ fn test_mutex_arc_nested() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn test_mutex_arc_access_in_unwind() {
     let arc = Arc::new(Mutex::new(1));
     let arc2 = arc.clone();

--- a/tests/sync-mutex.rs
+++ b/tests/sync-mutex.rs
@@ -92,6 +92,7 @@ fn test_into_inner_drop() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn test_into_inner_poison() {
     let m = Arc::new(Mutex::new(NonCopy(10)));
     let m2 = m.clone();
@@ -117,6 +118,7 @@ fn test_get_mut() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn test_get_mut_poison() {
     let m = Arc::new(Mutex::new(NonCopy(10)));
     let m2 = m.clone();
@@ -189,6 +191,7 @@ fn test_arc_condvar_poison() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn test_mutex_arc_poison() {
     let arc = Arc::new(Mutex::new(1));
     assert!(!arc.is_poisoned());
@@ -220,6 +223,7 @@ fn test_mutex_arc_nested() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn test_mutex_arc_access_in_unwind() {
     let arc = Arc::new(Mutex::new(1));
     let arc2 = arc.clone();

--- a/tests/sync-once.rs
+++ b/tests/sync-once.rs
@@ -1,6 +1,6 @@
 //! The following is derived from Rust's
 //! library/std/src/sync/once/tests.rs at revision
-//! 497ee321af3b8496eaccd7af7b437f18bab81abf.
+//! f42e96149dd03e816b8bc3c329e7b9a5d12fcdab.
 
 mustang::can_run_this!();
 
@@ -57,7 +57,6 @@ fn stampede_once() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn poison_bad() {
     static O: Once = Once::new();
 
@@ -87,7 +86,6 @@ fn poison_bad() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn wait_for_force_to_finish() {
     static O: Once = Once::new();
 

--- a/tests/sync-once.rs
+++ b/tests/sync-once.rs
@@ -57,6 +57,7 @@ fn stampede_once() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn poison_bad() {
     static O: Once = Once::new();
 
@@ -86,6 +87,7 @@ fn poison_bad() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn wait_for_force_to_finish() {
     static O: Once = Once::new();
 

--- a/tests/sync-rwlock.rs
+++ b/tests/sync-rwlock.rs
@@ -51,6 +51,7 @@ fn frob() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn test_rw_arc_poison_wr() {
     let arc = Arc::new(RwLock::new(1));
     let arc2 = arc.clone();
@@ -64,6 +65,7 @@ fn test_rw_arc_poison_wr() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn test_rw_arc_poison_ww() {
     let arc = Arc::new(RwLock::new(1));
     assert!(!arc.is_poisoned());
@@ -79,6 +81,7 @@ fn test_rw_arc_poison_ww() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn test_rw_arc_no_poison_rr() {
     let arc = Arc::new(RwLock::new(1));
     let arc2 = arc.clone();
@@ -92,6 +95,7 @@ fn test_rw_arc_no_poison_rr() {
 }
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn test_rw_arc_no_poison_rw() {
     let arc = Arc::new(RwLock::new(1));
     let arc2 = arc.clone();
@@ -144,6 +148,7 @@ fn test_rw_arc() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn test_rw_arc_access_in_unwind() {
     let arc = Arc::new(RwLock::new(1));
     let arc2 = arc.clone();
@@ -221,6 +226,7 @@ fn test_into_inner_drop() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn test_into_inner_poison() {
     let m = Arc::new(RwLock::new(NonCopy(10)));
     let m2 = m.clone();
@@ -246,6 +252,7 @@ fn test_get_mut() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn test_get_mut_poison() {
     let m = Arc::new(RwLock::new(NonCopy(10)));
     let m2 = m.clone();

--- a/tests/sync-rwlock.rs
+++ b/tests/sync-rwlock.rs
@@ -1,6 +1,6 @@
 //! The following is derived from Rust's
 //! library/std/src/sync/rwlock/tests.rs at revision
-//! 497ee321af3b8496eaccd7af7b437f18bab81abf.
+//! 72a25d05bf1a4b155d74139ef700ff93af6d8e22.
 
 mustang::can_run_this!();
 
@@ -23,7 +23,6 @@ fn smoke() {
 }
 
 #[test]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn frob() {
     const N: u32 = 10;
     const M: usize = 1000;
@@ -52,7 +51,6 @@ fn frob() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn test_rw_arc_poison_wr() {
     let arc = Arc::new(RwLock::new(1));
     let arc2 = arc.clone();
@@ -66,7 +64,6 @@ fn test_rw_arc_poison_wr() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn test_rw_arc_poison_ww() {
     let arc = Arc::new(RwLock::new(1));
     assert!(!arc.is_poisoned());
@@ -82,7 +79,6 @@ fn test_rw_arc_poison_ww() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn test_rw_arc_no_poison_rr() {
     let arc = Arc::new(RwLock::new(1));
     let arc2 = arc.clone();
@@ -96,7 +92,6 @@ fn test_rw_arc_no_poison_rr() {
 }
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn test_rw_arc_no_poison_rw() {
     let arc = Arc::new(RwLock::new(1));
     let arc2 = arc.clone();
@@ -149,7 +144,6 @@ fn test_rw_arc() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn test_rw_arc_access_in_unwind() {
     let arc = Arc::new(RwLock::new(1));
     let arc2 = arc.clone();
@@ -227,7 +221,6 @@ fn test_into_inner_drop() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn test_into_inner_poison() {
     let m = Arc::new(RwLock::new(NonCopy(10)));
     let m2 = m.clone();
@@ -240,7 +233,7 @@ fn test_into_inner_poison() {
     assert!(m.is_poisoned());
     match Arc::try_unwrap(m).unwrap().into_inner() {
         Err(e) => assert_eq!(e.into_inner(), NonCopy(10)),
-        Ok(x) => panic!("into_inner of poisoned RwLock is Ok: {:?}", x),
+        Ok(x) => panic!("into_inner of poisoned RwLock is Ok: {x:?}"),
     }
 }
 
@@ -253,7 +246,6 @@ fn test_get_mut() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 fn test_get_mut_poison() {
     let m = Arc::new(RwLock::new(NonCopy(10)));
     let m2 = m.clone();
@@ -266,6 +258,6 @@ fn test_get_mut_poison() {
     assert!(m.is_poisoned());
     match Arc::try_unwrap(m).unwrap().get_mut() {
         Err(e) => assert_eq!(*e.into_inner(), NonCopy(10)),
-        Ok(x) => panic!("get_mut of poisoned RwLock is Ok: {:?}", x),
+        Ok(x) => panic!("get_mut of poisoned RwLock is Ok: {x:?}"),
     }
 }

--- a/tests/thread.rs
+++ b/tests/thread.rs
@@ -1,6 +1,6 @@
 //! The following is derived from Rust's
 //! library/std/src/thread/tests.rs at revision
-//! 497ee321af3b8496eaccd7af7b437f18bab81abf.
+//! eb14dd863a0d8af603c6783b10efff8454944c15.
 
 #![feature(box_syntax)]
 #![cfg(feature = "threads")]
@@ -9,11 +9,17 @@ mustang::can_run_this!();
 
 use std::any::Any;
 use std::mem;
+use std::panic::panic_any;
 use std::result;
-use std::sync::mpsc::{channel, Sender};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    mpsc::{channel, Sender},
+    Arc, Barrier,
+};
 use std::thread::Builder;
-use std::thread::{self, ThreadId};
+use std::thread::{self, Scope, ThreadId};
 use std::time::Duration;
+use std::time::Instant;
 
 // !!! These tests are dangerous. If something is buggy, they will hang, !!!
 // !!! instead of exiting cleanly. This might wedge the buildbots.       !!!
@@ -42,7 +48,6 @@ fn test_named_thread() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): triggers segfault
 #[should_panic]
 fn test_invalid_named_thread() {
     let _ = Builder::new()
@@ -57,6 +62,36 @@ fn test_run_basic() {
         tx.send(()).unwrap();
     });
     rx.recv().unwrap();
+}
+
+#[test]
+fn test_is_finished() {
+    let b = Arc::new(Barrier::new(2));
+    let t = thread::spawn({
+        let b = b.clone();
+        move || {
+            b.wait();
+            1234
+        }
+    });
+
+    // Thread is definitely running here, since it's still waiting for the barrier.
+    assert_eq!(t.is_finished(), false);
+
+    // Unblock the barrier.
+    b.wait();
+
+    // Now check that t.is_finished() becomes true within a reasonable time.
+    let start = Instant::now();
+    while !t.is_finished() {
+        assert!(start.elapsed() < Duration::from_secs(2));
+        thread::sleep(Duration::from_millis(15));
+    }
+
+    // Joining the thread should not block for a significant time now.
+    let join_time = Instant::now();
+    assert_eq!(t.join().unwrap(), 1234);
+    assert!(join_time.elapsed() < Duration::from_secs(2));
 }
 
 #[test]
@@ -105,7 +140,7 @@ where
 {
     let (tx, rx) = channel();
 
-    let x: Box<_> = box 1;
+    let x: Box<_> = Box::new(1);
     let x_in_parent = (&*x) as *const i32 as usize;
 
     spawnfn(Box::new(move || {
@@ -164,7 +199,7 @@ fn test_simple_newsched_spawn() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-fn test_try_panic_message_static_str() {
+fn test_try_panic_message_string_literal() {
     match thread::spawn(move || {
         panic!("static string");
     })
@@ -182,9 +217,9 @@ fn test_try_panic_message_static_str() {
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 #[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): panics inside a panic
-fn test_try_panic_message_owned_str() {
+fn test_try_panic_any_message_owned_str() {
     match thread::spawn(move || {
-        panic!("owned string".to_string());
+        panic_any("owned string".to_string());
     })
     .join()
     {
@@ -200,9 +235,9 @@ fn test_try_panic_message_owned_str() {
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
 #[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): panics inside a panic
-fn test_try_panic_message_any() {
+fn test_try_panic_any_message_any() {
     match thread::spawn(move || {
-        panic!(box 413u16 as Box<dyn Any + Send>);
+        panic_any(Box::new(413u16) as Box<dyn Any + Send>);
     })
     .join()
     {
@@ -219,10 +254,10 @@ fn test_try_panic_message_any() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-fn test_try_panic_message_unit_struct() {
+fn test_try_panic_any_message_unit_struct() {
     struct Juju;
 
-    match thread::spawn(move || panic!(Juju)).join() {
+    match thread::spawn(move || panic_any(Juju)).join() {
         Err(ref e) if e.is::<Juju>() => {}
         Err(_) | Ok(()) => panic!(),
     }
@@ -281,5 +316,38 @@ fn test_thread_id_not_equal() {
     assert!(thread::current().id() != spawned_id);
 }
 
-// NOTE: the corresponding test for stderr is in ui/thread-stderr, due
-// to the test harness apparently interfering with stderr configuration.
+#[test]
+fn test_scoped_threads_drop_result_before_join() {
+    let actually_finished = &AtomicBool::new(false);
+    struct X<'scope, 'env>(&'scope Scope<'scope, 'env>, &'env AtomicBool);
+    impl Drop for X<'_, '_> {
+        fn drop(&mut self) {
+            thread::sleep(Duration::from_millis(20));
+            let actually_finished = self.1;
+            self.0.spawn(move || {
+                thread::sleep(Duration::from_millis(20));
+                actually_finished.store(true, Ordering::Relaxed);
+            });
+        }
+    }
+    thread::scope(|s| {
+        s.spawn(move || {
+            thread::sleep(Duration::from_millis(20));
+            X(s, actually_finished)
+        });
+    });
+    assert!(actually_finished.load(Ordering::Relaxed));
+}
+
+#[test]
+fn test_scoped_threads_nll() {
+    // this is mostly a *compilation test* for this exact function:
+    fn foo(x: &u8) {
+        thread::scope(|s| {
+            s.spawn(|| drop(x));
+        });
+    }
+    // let's also run it for good measure
+    let x = 42_u8;
+    foo(&x);
+}

--- a/tests/thread.rs
+++ b/tests/thread.rs
@@ -48,6 +48,7 @@ fn test_named_thread() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 #[should_panic]
 fn test_invalid_named_thread() {
     let _ = Builder::new()
@@ -96,6 +97,7 @@ fn test_is_finished() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn test_join_panic() {
     match thread::spawn(move || panic!()).join() {
         result::Result::Err(_) => (),
@@ -199,6 +201,7 @@ fn test_simple_newsched_spawn() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn test_try_panic_message_string_literal() {
     match thread::spawn(move || {
         panic!("static string");
@@ -216,7 +219,7 @@ fn test_try_panic_message_string_literal() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): panics inside a panic
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): panics inside a panic
 fn test_try_panic_any_message_owned_str() {
     match thread::spawn(move || {
         panic_any("owned string".to_string());
@@ -234,7 +237,7 @@ fn test_try_panic_any_message_owned_str() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
-#[cfg_attr(all(target_vendor = "mustang", not(target_arch = "x86-64")), ignore)] // FIXME(mustang): panics inside a panic
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): panics inside a panic
 fn test_try_panic_any_message_any() {
     match thread::spawn(move || {
         panic_any(Box::new(413u16) as Box<dyn Any + Send>);
@@ -254,6 +257,7 @@ fn test_try_panic_any_message_any() {
 
 #[test]
 #[cfg_attr(all(target_arch = "arm", not(feature = "unwinding")), ignore)]
+#[cfg_attr(all(target_vendor = "mustang", target_arch = "x86"), ignore)] // FIXME(mustang): triggers segfault
 fn test_try_panic_any_message_unit_struct() {
     struct Juju;
 


### PR DESCRIPTION
Update tests/thread.rs and tests/sync-mutex.rs to the latest upstream, and fix unused-import warnings in tests. 

Also, update to Rust 2021 edition, as the updated tests depend on it.