### PR TITLE
Fix the layout of the pthread types on aarch64.

### DIFF
--- a/c-scape/src/net/mod.rs
+++ b/c-scape/src/net/mod.rs
@@ -29,9 +29,8 @@ unsafe extern "C" fn accept(
     addr: *mut SocketAddrStorage,
     len: *mut libc::socklen_t,
 ) -> c_int {
-    // FIXME(#95) layout of addr doesn't match signature on i686
-    // uncomment once it does:
-    // libc!(libc::accept(fd, checked_cast!(addr), len));
+    // We don't use `checked_cast` here because libc uses `sockaddr` which
+    // just represents the header of the struct, not the full storage.
     libc!(libc::accept(fd, addr.cast(), len));
 
     match convert_res(rustix::net::acceptfrom(BorrowedFd::borrow_raw(fd))) {
@@ -53,9 +52,8 @@ unsafe extern "C" fn accept4(
     len: *mut libc::socklen_t,
     flags: c_int,
 ) -> c_int {
-    // FIXME(#95) layout of addr doesn't match signature on i686
-    // uncomment once it does:
-    // libc!(libc::accept4(fd, checked_cast!(addr), len, flags));
+    // We don't use `checked_cast` here because libc uses `sockaddr` which
+    // just represents the header of the struct, not the full storage.
     libc!(libc::accept4(fd, addr.cast(), len, flags));
 
     let flags = AcceptFlags::from_bits(flags as _).unwrap();
@@ -80,9 +78,8 @@ unsafe extern "C" fn bind(
     addr: *const SocketAddrStorage,
     len: libc::socklen_t,
 ) -> c_int {
-    // FIXME(#95) layout of addr doesn't match signature on i686
-    // uncomment once it does:
-    // libc!(libc::bind(sockfd, checked_cast!(addr), len));
+    // We don't use `checked_cast` here because libc uses `sockaddr` which
+    // just represents the header of the struct, not the full storage.
     libc!(libc::bind(sockfd, addr.cast(), len));
 
     let addr = match convert_res(SocketAddrAny::read(addr, len.try_into().unwrap())) {
@@ -106,9 +103,8 @@ unsafe extern "C" fn connect(
     addr: *const SocketAddrStorage,
     len: libc::socklen_t,
 ) -> c_int {
-    // FIXME(#95) layout of addr doesn't match signature on i686
-    // uncomment once it does:
-    // libc!(libc::connect(sockfd, checked_cast!(addr), len));
+    // We don't use `checked_cast` here because libc uses `sockaddr` which
+    // just represents the header of the struct, not the full storage.
     libc!(libc::connect(sockfd, addr.cast(), len));
 
     let addr = match convert_res(SocketAddrAny::read(addr, len.try_into().unwrap())) {
@@ -134,9 +130,8 @@ unsafe extern "C" fn getpeername(
     addr: *mut SocketAddrStorage,
     len: *mut libc::socklen_t,
 ) -> c_int {
-    // FIXME(#95) layout of addr doesn't match signature on i686
-    // uncomment once it does:
-    // libc!(libc::getpeername(fd, checked_cast!(addr), len));
+    // We don't use `checked_cast` here because libc uses `sockaddr` which
+    // just represents the header of the struct, not the full storage.
     libc!(libc::getpeername(fd, addr.cast(), len));
 
     match convert_res(rustix::net::getpeername(BorrowedFd::borrow_raw(fd))) {
@@ -157,9 +152,8 @@ unsafe extern "C" fn getsockname(
     addr: *mut SocketAddrStorage,
     len: *mut libc::socklen_t,
 ) -> c_int {
-    // FIXME(#95) layout of addr doesn't match signature on i686
-    // uncomment once it does:
-    // libc!(libc::getsockname(fd, checked_cast!(addr), len));
+    // We don't use `checked_cast` here because libc uses `sockaddr` which
+    // just represents the header of the struct, not the full storage.
     libc!(libc::getsockname(fd, addr.cast(), len));
 
     match convert_res(rustix::net::getsockname(BorrowedFd::borrow_raw(fd))) {
@@ -619,9 +613,8 @@ unsafe extern "C" fn recvfrom(
     from: *mut SocketAddrStorage,
     from_len: *mut libc::socklen_t,
 ) -> isize {
-    // FIXME(#95) layout of from doesn't match signature on i686
-    // uncomment once it does:
-    // libc!(libc::recvfrom(fd, buf, len, flags, checked_cast!(from), from_len));
+    // We don't use `checked_cast` here because libc uses `sockaddr` which
+    // just represents the header of the struct, not the full storage.
     libc!(libc::recvfrom(fd, buf, len, flags, from.cast(), from_len));
 
     let flags = RecvFlags::from_bits(flags as _).unwrap();
@@ -665,9 +658,8 @@ unsafe extern "C" fn sendto(
     to: *const SocketAddrStorage,
     to_len: libc::socklen_t,
 ) -> isize {
-    // FIXME(#95) layout of to doesn't match signature on i686
-    // uncomment once it does:
-    // libc!(libc::sendto(fd, buf, len, flags, checked_cast!(to), to_len));
+    // We don't use `checked_cast` here because libc uses `sockaddr` which
+    // just represents the header of the struct, not the full storage.
     libc!(libc::sendto(fd, buf, len, flags, to.cast(), to_len));
 
     let flags = SendFlags::from_bits(flags as _).unwrap();

--- a/c-scape/src/threads/mod.rs
+++ b/c-scape/src/threads/mod.rs
@@ -154,7 +154,11 @@ unsafe extern "C" fn pthread_attr_getstack(
     stackaddr: *mut *mut c_void,
     stacksize: *mut usize,
 ) -> c_int {
-    libc!(libc::pthread_attr_getstack(checked_cast!(attr), stackaddr, stacksize));
+    libc!(libc::pthread_attr_getstack(
+        checked_cast!(attr),
+        stackaddr,
+        stacksize
+    ));
     *stackaddr = (*attr).stack_addr;
     *stacksize = (*attr).stack_size;
     0
@@ -239,7 +243,10 @@ unsafe extern "C" fn pthread_mutex_init(
     mutex: *mut PthreadMutexT,
     mutexattr: *const PthreadMutexattrT,
 ) -> c_int {
-    libc!(libc::pthread_mutex_init(checked_cast!(mutex), checked_cast!(mutexattr)));
+    libc!(libc::pthread_mutex_init(
+        checked_cast!(mutex),
+        checked_cast!(mutexattr)
+    ));
     let kind = (*mutexattr).kind.load(SeqCst);
     match kind as i32 {
         libc::PTHREAD_MUTEX_NORMAL => ptr::write(&mut (*mutex).u.normal, RawMutex::INIT),
@@ -351,7 +358,10 @@ unsafe extern "C" fn pthread_attr_getguardsize(
     attr: *const PthreadAttrT,
     guardsize: *mut usize,
 ) -> c_int {
-    libc!(libc::pthread_attr_getguardsize(checked_cast!(attr), guardsize));
+    libc!(libc::pthread_attr_getguardsize(
+        checked_cast!(attr),
+        guardsize
+    ));
     *guardsize = (*attr).guard_size;
     0
 }
@@ -487,7 +497,10 @@ unsafe extern "C" fn pthread_cond_signal(cond: *mut PthreadCondT) -> c_int {
 
 #[no_mangle]
 unsafe extern "C" fn pthread_cond_wait(cond: *mut PthreadCondT, lock: *mut PthreadMutexT) -> c_int {
-    libc!(libc::pthread_cond_wait(checked_cast!(cond), checked_cast!(lock)));
+    libc!(libc::pthread_cond_wait(
+        checked_cast!(cond),
+        checked_cast!(lock)
+    ));
     let _ = (cond, lock);
     rustix::io::write(&rustix::io::stderr(), b"unimplemented: pthread_cond_wait\n").ok();
     0
@@ -499,7 +512,11 @@ unsafe extern "C" fn pthread_cond_timedwait(
     lock: *mut PthreadMutexT,
     abstime: *const libc::timespec,
 ) -> c_int {
-    libc!(libc::pthread_cond_timedwait(checked_cast!(cond), checked_cast!(lock), abstime));
+    libc!(libc::pthread_cond_timedwait(
+        checked_cast!(cond),
+        checked_cast!(lock),
+        abstime
+    ));
     let _ = (cond, lock, abstime);
     rustix::io::write(
         &rustix::io::stderr(),
@@ -599,7 +616,10 @@ unsafe extern "C" fn pthread_sigmask() -> c_int {
 
 #[no_mangle]
 unsafe extern "C" fn pthread_attr_setstacksize(attr: *mut PthreadAttrT, stacksize: usize) -> c_int {
-    libc!(libc::pthread_attr_setstacksize(checked_cast!(attr), stacksize));
+    libc!(libc::pthread_attr_setstacksize(
+        checked_cast!(attr),
+        stacksize
+    ));
     (*attr).stack_size = stacksize;
     0
 }

--- a/c-scape/src/threads/mod.rs
+++ b/c-scape/src/threads/mod.rs
@@ -111,9 +111,10 @@ unsafe extern "C" fn pthread_self() -> PthreadT {
 
 #[no_mangle]
 unsafe extern "C" fn pthread_getattr_np(thread: PthreadT, attr: *mut PthreadAttrT) -> c_int {
-    // FIXME(#95) layout of attr doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_getattr_np(thread, checked_cast!(attr)));
+    libc!(libc::pthread_getattr_np(
+        thread.expose_addr() as _,
+        checked_cast!(attr)
+    ));
     let (stack_addr, stack_size, guard_size) = origin::thread_stack(thread.cast());
     ptr::write(
         attr,
@@ -550,9 +551,12 @@ unsafe extern "C" fn pthread_create(
     fn_: extern "C" fn(*mut c_void) -> *mut c_void,
     arg: *mut c_void,
 ) -> c_int {
-    // FIXME(#95) layout of attr doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_create(pthread, checked_cast!(attr), fn_, arg));
+    libc!(libc::pthread_create(
+        checked_cast!(pthread),
+        checked_cast!(attr),
+        fn_,
+        arg
+    ));
     let PthreadAttrT {
         stack_addr,
         stack_size,

--- a/c-scape/src/threads/mod.rs
+++ b/c-scape/src/threads/mod.rs
@@ -38,7 +38,7 @@ struct PthreadAttrT {
     pad1: usize,
     pad2: usize,
     pad3: usize,
-    #[cfg(target_arch = "x86")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86"))]
     pad4: usize,
     #[cfg(target_arch = "x86")]
     pad5: usize,
@@ -55,7 +55,7 @@ impl Default for PthreadAttrT {
             pad1: 0,
             pad2: 0,
             pad3: 0,
-            #[cfg(target_arch = "x86")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86"))]
             pad4: 0,
             #[cfg(target_arch = "x86")]
             pad5: 0,
@@ -76,7 +76,7 @@ struct PthreadMutexT {
     kind: AtomicU32,
     u: pthread_mutex_u,
     pad0: usize,
-    #[cfg(target_arch = "x86")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86"))]
     pad1: usize,
 }
 libc_type!(PthreadMutexT, pthread_mutex_t);
@@ -98,6 +98,8 @@ libc_type!(PthreadRwlockT, pthread_rwlock_t);
 #[repr(C)]
 struct PthreadMutexattrT {
     kind: AtomicU32,
+    #[cfg(target_arch = "aarch64")]
+    pad0: u32,
 }
 libc_type!(PthreadMutexattrT, pthread_mutexattr_t);
 
@@ -123,7 +125,7 @@ unsafe extern "C" fn pthread_getattr_np(thread: PthreadT, attr: *mut PthreadAttr
             pad1: 0,
             pad2: 0,
             pad3: 0,
-            #[cfg(target_arch = "x86")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86"))]
             pad4: 0,
             #[cfg(target_arch = "x86")]
             pad5: 0,
@@ -134,18 +136,14 @@ unsafe extern "C" fn pthread_getattr_np(thread: PthreadT, attr: *mut PthreadAttr
 
 #[no_mangle]
 unsafe extern "C" fn pthread_attr_init(attr: *mut PthreadAttrT) -> c_int {
-    // FIXME(#95) layout of attr doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_attr_init(checked_cast!(attr)));
+    libc!(libc::pthread_attr_init(checked_cast!(attr)));
     ptr::write(attr, PthreadAttrT::default());
     0
 }
 
 #[no_mangle]
 unsafe extern "C" fn pthread_attr_destroy(attr: *mut PthreadAttrT) -> c_int {
-    // FIXME(#95) layout of attr doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_attr_destroy(checked_cast!(attr)));
+    libc!(libc::pthread_attr_destroy(checked_cast!(attr)));
     ptr::drop_in_place(attr);
     0
 }
@@ -156,9 +154,7 @@ unsafe extern "C" fn pthread_attr_getstack(
     stackaddr: *mut *mut c_void,
     stacksize: *mut usize,
 ) -> c_int {
-    // FIXME(#95) layout of attr doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_attr_getstack(checked_cast!(attr), stackaddr, stacksize));
+    libc!(libc::pthread_attr_getstack(checked_cast!(attr), stackaddr, stacksize));
     *stackaddr = (*attr).stack_addr;
     *stacksize = (*attr).stack_size;
     0
@@ -199,22 +195,20 @@ unsafe extern "C" fn pthread_key_delete() -> c_int {
 
 #[no_mangle]
 unsafe extern "C" fn pthread_mutexattr_destroy(attr: *mut PthreadMutexattrT) -> c_int {
-    // FIXME(#95) layout of attr doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_mutexattr_destroy(checked_cast!(attr)));
+    libc!(libc::pthread_mutexattr_destroy(checked_cast!(attr)));
     ptr::drop_in_place(attr);
     0
 }
 
 #[no_mangle]
 unsafe extern "C" fn pthread_mutexattr_init(attr: *mut PthreadMutexattrT) -> c_int {
-    // FIXME(#95) layout of attr doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_mutexattr_init(checked_cast!(attr)));
+    libc!(libc::pthread_mutexattr_init(checked_cast!(attr)));
     ptr::write(
         attr,
         PthreadMutexattrT {
             kind: AtomicU32::new(libc::PTHREAD_MUTEX_DEFAULT as u32),
+            #[cfg(target_arch = "aarch64")]
+            pad0: 0,
         },
     );
     0
@@ -222,18 +216,14 @@ unsafe extern "C" fn pthread_mutexattr_init(attr: *mut PthreadMutexattrT) -> c_i
 
 #[no_mangle]
 unsafe extern "C" fn pthread_mutexattr_settype(attr: *mut PthreadMutexattrT, kind: c_int) -> c_int {
-    // FIXME(#95) layout of attr doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_mutexattr_settype(checked_cast!(attr), kind));
+    libc!(libc::pthread_mutexattr_settype(checked_cast!(attr), kind));
     (*attr).kind = AtomicU32::new(kind as u32);
     0
 }
 
 #[no_mangle]
 unsafe extern "C" fn pthread_mutex_destroy(mutex: *mut PthreadMutexT) -> c_int {
-    // FIXME(#95) layout of mutex doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_mutex_destroy(checked_cast!(mutex)));
+    libc!(libc::pthread_mutex_destroy(checked_cast!(mutex)));
     match (*mutex).kind.load(SeqCst) as i32 {
         libc::PTHREAD_MUTEX_NORMAL => ptr::drop_in_place(&mut (*mutex).u.normal),
         libc::PTHREAD_MUTEX_RECURSIVE => ptr::drop_in_place(&mut (*mutex).u.reentrant),
@@ -249,9 +239,7 @@ unsafe extern "C" fn pthread_mutex_init(
     mutex: *mut PthreadMutexT,
     mutexattr: *const PthreadMutexattrT,
 ) -> c_int {
-    // FIXME(#95) layout of mutex and attr doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_mutex_init(checked_cast!(mutex), checked_cast!(mutexattr)));
+    libc!(libc::pthread_mutex_init(checked_cast!(mutex), checked_cast!(mutexattr)));
     let kind = (*mutexattr).kind.load(SeqCst);
     match kind as i32 {
         libc::PTHREAD_MUTEX_NORMAL => ptr::write(&mut (*mutex).u.normal, RawMutex::INIT),
@@ -267,9 +255,7 @@ unsafe extern "C" fn pthread_mutex_init(
 
 #[no_mangle]
 unsafe extern "C" fn pthread_mutex_lock(mutex: *mut PthreadMutexT) -> c_int {
-    // FIXME(#95) layout of mutex doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_mutex_lock(checked_cast!(mutex)));
+    libc!(libc::pthread_mutex_lock(checked_cast!(mutex)));
     match (*mutex).kind.load(SeqCst) as i32 {
         libc::PTHREAD_MUTEX_NORMAL => (*mutex).u.normal.lock(),
         libc::PTHREAD_MUTEX_RECURSIVE => (*mutex).u.reentrant.lock(),
@@ -281,9 +267,7 @@ unsafe extern "C" fn pthread_mutex_lock(mutex: *mut PthreadMutexT) -> c_int {
 
 #[no_mangle]
 unsafe extern "C" fn pthread_mutex_trylock(mutex: *mut PthreadMutexT) -> c_int {
-    // FIXME(#95) layout of mutex doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_mutex_trylock(checked_cast!(mutex)));
+    libc!(libc::pthread_mutex_trylock(checked_cast!(mutex)));
     if match (*mutex).kind.load(SeqCst) as i32 {
         libc::PTHREAD_MUTEX_NORMAL => (*mutex).u.normal.try_lock(),
         libc::PTHREAD_MUTEX_RECURSIVE => (*mutex).u.reentrant.try_lock(),
@@ -298,9 +282,7 @@ unsafe extern "C" fn pthread_mutex_trylock(mutex: *mut PthreadMutexT) -> c_int {
 
 #[no_mangle]
 unsafe extern "C" fn pthread_mutex_unlock(mutex: *mut PthreadMutexT) -> c_int {
-    // FIXME(#95) layout of mutex doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_mutex_unlock(checked_cast!(mutex)));
+    libc!(libc::pthread_mutex_unlock(checked_cast!(mutex)));
     match (*mutex).kind.load(SeqCst) as i32 {
         libc::PTHREAD_MUTEX_NORMAL => (*mutex).u.normal.unlock(),
         libc::PTHREAD_MUTEX_RECURSIVE => (*mutex).u.reentrant.unlock(),
@@ -369,9 +351,7 @@ unsafe extern "C" fn pthread_attr_getguardsize(
     attr: *const PthreadAttrT,
     guardsize: *mut usize,
 ) -> c_int {
-    // FIXME(#95) layout of attr doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_attr_getguardsize(checked_cast!(attr), guardsize));
+    libc!(libc::pthread_attr_getguardsize(checked_cast!(attr), guardsize));
     *guardsize = (*attr).guard_size;
     0
 }
@@ -507,9 +487,7 @@ unsafe extern "C" fn pthread_cond_signal(cond: *mut PthreadCondT) -> c_int {
 
 #[no_mangle]
 unsafe extern "C" fn pthread_cond_wait(cond: *mut PthreadCondT, lock: *mut PthreadMutexT) -> c_int {
-    // FIXME(#95) layout of lock doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_cond_wait(checked_cast!(cond), checked_cast!(lock));
+    libc!(libc::pthread_cond_wait(checked_cast!(cond), checked_cast!(lock)));
     let _ = (cond, lock);
     rustix::io::write(&rustix::io::stderr(), b"unimplemented: pthread_cond_wait\n").ok();
     0
@@ -521,9 +499,7 @@ unsafe extern "C" fn pthread_cond_timedwait(
     lock: *mut PthreadMutexT,
     abstime: *const libc::timespec,
 ) -> c_int {
-    // FIXME(#95) layout of mutex doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_cond_timedwait(checked_cast!(cond), checked_cast!(lock), abstime));
+    libc!(libc::pthread_cond_timedwait(checked_cast!(cond), checked_cast!(lock), abstime));
     let _ = (cond, lock, abstime);
     rustix::io::write(
         &rustix::io::stderr(),
@@ -568,7 +544,7 @@ unsafe extern "C" fn pthread_create(
         pad1: _,
         pad2: _,
         pad3: _,
-        #[cfg(target_arch = "x86")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "x86"))]
             pad4: _,
         #[cfg(target_arch = "x86")]
             pad5: _,
@@ -623,9 +599,7 @@ unsafe extern "C" fn pthread_sigmask() -> c_int {
 
 #[no_mangle]
 unsafe extern "C" fn pthread_attr_setstacksize(attr: *mut PthreadAttrT, stacksize: usize) -> c_int {
-    // FIXME(#95) layout of attr doesn't match signature on aarch64
-    // uncomment once it does:
-    // libc!(libc::pthread_attr_setstacksize(checked_cast!(attr), stacksize));
+    libc!(libc::pthread_attr_setstacksize(checked_cast!(attr), stacksize));
     (*attr).stack_size = stacksize;
     0
 }


### PR DESCRIPTION
This fixes most of the the pthread parts of #94.