### PR TITLE
Add a new c-gull crate, which is an above-std libc implementation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ exclude = ["/.github"]
 publish = false
 
 [dev-dependencies]
-origin = { path = "origin", version = "^0.5.0" }
 mustang = { path = "mustang", version = "^0.5.0" }
 c-scape = { path = "c-scape", version = "^0.5.0" }
+c-gull = { path = "c-gull", version = "^0.5.0" }
 similar-asserts = "1.1.0"
 rand = "0.8.4"
 libc = "0.2.126"
@@ -29,9 +29,10 @@ ctor = "0.1.21"
 
 [features]
 default = ["threads"]
-threads = ["origin/threads", "mustang/threads"]
-env_logger = ["origin/env_logger"]
-max_level_off = ["origin/max_level_off"]
+threads = ["mustang/threads"]
+env_logger = ["mustang/env_logger"]
+log = ["mustang/log"]
+max_level_off = ["mustang/max_level_off"]
 
 # Enable the cc dependency to build assembly-code libraries from .s sources
 # instead of using the prebuilt libraries.
@@ -42,13 +43,5 @@ members = [
   "mustang",
   "origin",
   "c-scape",
+  "c-gull",
 ]
-
-# These profile settings make rustc emit all of c-scape's code as one single
-# object file, eliminating unused symbol errors from the linker simply not
-# choosing to link in the object file containing needed symbols.
-[profile.dev.package.c-scape]
-codegen-units = 1
-
-[profile.release.package.c-scape]
-codegen-units = 1

--- a/c-gull/COPYRIGHT
+++ b/c-gull/COPYRIGHT
@@ -1,0 +1,29 @@
+Short version for non-lawyers:
+
+`c-scape` is triple-licensed under Apache 2.0 with the LLVM Exception,
+Apache 2.0, and MIT terms.
+
+
+Longer version:
+
+Copyrights in the `c-scape` project are retained by their contributors.
+No copyright assignment is required to contribute to the `c-scape`
+project.
+
+Some files include code derived from Rust's `libstd`; see the comments in
+the code for details.
+
+Except as otherwise noted (below and/or in individual files), `c-scape`
+is licensed under:
+
+ - the Apache License, Version 2.0, with the LLVM Exception
+   <LICENSE-Apache-2.0_WITH_LLVM-exception> or
+   <http://llvm.org/foundation/relicensing/LICENSE.txt>
+ - the Apache License, Version 2.0
+   <LICENSE-APACHE> or
+   <http://www.apache.org/licenses/LICENSE-2.0>,
+ - or the MIT license
+   <LICENSE-MIT> or
+   <http://opensource.org/licenses/MIT>,
+
+at your option.

--- a/c-gull/COPYRIGHT
+++ b/c-gull/COPYRIGHT
@@ -1,19 +1,19 @@
 Short version for non-lawyers:
 
-`c-scape` is triple-licensed under Apache 2.0 with the LLVM Exception,
+`c-gull` is triple-licensed under Apache 2.0 with the LLVM Exception,
 Apache 2.0, and MIT terms.
 
 
 Longer version:
 
-Copyrights in the `c-scape` project are retained by their contributors.
-No copyright assignment is required to contribute to the `c-scape`
+Copyrights in the `c-gull` project are retained by their contributors.
+No copyright assignment is required to contribute to the `c-gull`
 project.
 
 Some files include code derived from Rust's `libstd`; see the comments in
 the code for details.
 
-Except as otherwise noted (below and/or in individual files), `c-scape`
+Except as otherwise noted (below and/or in individual files), `c-gull`
 is licensed under:
 
  - the Apache License, Version 2.0, with the LLVM Exception

--- a/c-gull/Cargo.toml
+++ b/c-gull/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "c-gull"
+version = "0.5.1"
+authors = [
+    "Dan Gohman <dev@sunfishcode.online>",
+]
+description = "A libc implementation in Rust"
+documentation = "https://docs.rs/c-gull"
+license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+repository = "https://github.com/sunfishcode/mustang"
+edition = "2021"
+
+[dependencies]
+rustix = { version = "0.35.6", default-features = false, features = ["fs", "itoa", "net", "param", "process", "rand", "termios", "thread", "time"] }
+# We use the libc crate for C ABI types and constants, but we don't depend on
+# the actual platform libc.
+libc = { version = "0.2.126", default-features = false }
+errno = { version = "0.2.8", default-features = false }
+c-scape = { path = "../c-scape" }
+tz-rs = "0.6.11"
+printf-compat = "0.1.1"
+rand = "0.8.5"
+log = { version = "0.4.14", default-features = false }
+
+[dev-dependencies]
+libc = "0.2.126"
+
+[features]
+default = ["threads"]
+threads = ["c-scape/threads"]

--- a/c-gull/LICENSE-APACHE
+++ b/c-gull/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/c-gull/LICENSE-Apache-2.0_WITH_LLVM-exception
+++ b/c-gull/LICENSE-Apache-2.0_WITH_LLVM-exception
@@ -1,0 +1,220 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+

--- a/c-gull/LICENSE-MIT
+++ b/c-gull/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/c-gull/README.md
+++ b/c-gull/README.md
@@ -1,0 +1,68 @@
+<div align="center">
+  <h1><code>c-gull</code></h1>
+
+  <p>
+    <strong>A libc implementation in Rust</strong>
+  </p>
+
+  <p>
+    <a href="https://github.com/sunfishcode/mustang/actions?query=workflow%3ACI"><img src="https://github.com/sunfishcode/mustang/workflows/CI/badge.svg" alt="Github Actions CI Status" /></a>
+    <a href="https://bytecodealliance.zulipchat.com/#narrow/stream/206238-general"><img src="https://img.shields.io/badge/zulip-join_chat-brightgreen.svg" alt="zulip chat" /></a>
+    <a href="https://crates.io/crates/c-gull"><img src="https://img.shields.io/crates/v/c-gull.svg" alt="crates.io page" /></a>
+    <a href="https://docs.rs/c-gull"><img src="https://docs.rs/c-gull/badge.svg" alt="docs.rs docs" /></a>
+  </p>
+</div>
+
+c-gull is a libc implementation. It is an implementation of the ABI described
+by the [libc] crate.
+
+It is implemented in terms of crates written in Rust, such as [c-scape],
+[rustix], [origin], [sync-resolve], [libm], [realpath-ext], [memchr], [tz-rs],
+[printf-compat], and [rand].
+
+Currently it only supports `*-*-linux-gnu` ABIs, though other ABIs could be
+added in the future. And currently this mostly focused on features needed by
+Rust programs, so it doesn't have many C-idiomatic things like `printf` yet, but
+they could be added in the future.
+
+The goal is to have very little code in c-gull itself, by factoring out all of
+the significant functionality into independent crates with more Rust-idiomatic
+APIs, with c-gull just wrapping those APIs to implement the C ABIs.
+
+This is currently highly experimental, incomplete, and some things aren't
+optimized.
+
+This is part of the [Mustang] project, building Rust programs written entirely
+in Rust.
+
+## Using c-gull in non-mustang programs
+
+c-gull can also be used as a drop-in (partial) libc replacement in non-mustang
+builds, provided you're using nightly Rust. To use it, just change your typical
+libc dependency in Cargo.toml to this:
+
+```toml
+libc = { version = "<c-gull version>", package = "c-gull" }
+```
+
+and c-gull will replace as many of the system libc implementation with its own
+implementations as it can. In particular, it can't replace `malloc` or any of
+the pthread functions in this configuration, but it can replace many other
+things.
+
+See the [libc-replacement example] for more details.
+
+[libc-replacement example]: https://github.com/sunfishcode/mustang/blob/main/test-crates/libc-replacement/README.md
+[Mustang]: https://github.com/sunfishcode/mustang/
+[c-scape]: https://crates.io/crates/c-scape
+[rustix]: https://crates.io/crates/rustix
+[origin]: https://crates.io/crates/origin
+[sync-resolve]: https://crates.io/crates/sync-resolve
+[libm]: https://crates.io/crates/libm
+[libc]: https://crates.io/crates/libc
+[realpath-ext]: https://crates.io/crates/realpath-ext
+[memchr]: https://crates.io/crates/memchr
+[mustang]: https://crates.io/crates/mustang
+[tz-rs]: https://crates.io/crates/tz-rs
+[printf-compat]: https://crates.io/crates/printf-compat
+[rand]: https://crates.io/crates/rand

--- a/c-gull/src/lib.rs
+++ b/c-gull/src/lib.rs
@@ -1,0 +1,43 @@
+#![doc = include_str!("../README.md")]
+#![no_builtins] // don't let LLVM optimize our `memcpy` into a `memcpy` call
+#![feature(strict_provenance)]
+#![feature(c_variadic)]
+#![deny(fuzzy_provenance_casts)]
+#![deny(lossy_provenance_casts)]
+
+extern crate c_scape;
+
+// Re-export the libc crate's API. This allows users to depend on the c-scape
+// crate in place of libc.
+pub use libc::*;
+
+#[macro_use]
+mod use_libc;
+
+mod nss;
+mod printf;
+mod rand48;
+mod strtod;
+mod strtol;
+mod time;
+
+use std::ffi::CStr;
+
+#[no_mangle]
+unsafe extern "C" fn __assert_fail(
+    expr: *const c_char,
+    file: *const c_char,
+    line: c_int,
+    func: *const c_char,
+) -> ! {
+    //libc!(libc::__assert_fail(expr, file, line, func));
+
+    eprintln!(
+        "Assertion failed: {:?} ({:?}:{}: {:?})",
+        CStr::from_ptr(expr),
+        CStr::from_ptr(file),
+        line,
+        CStr::from_ptr(func)
+    );
+    std::process::abort();
+}

--- a/c-gull/src/nss.rs
+++ b/c-gull/src/nss.rs
@@ -1,0 +1,367 @@
+//! Name Service Switch functions.
+//!
+//! In order to avoid implementing `dlopen`, while still correctly implementing
+//! fully /etc/nsswitch.conf-respecting NSS functionality, we invoke the
+//! `getent` command and parse its output.
+//!
+//! This file doesn't yet implement enumeration, but the `getent` command does,
+//! so it's theoretically doable.
+
+use libc::{c_char, c_int, c_void, gid_t, group, passwd, uid_t};
+use rustix::path::DecInt;
+use std::ffi::{CStr, OsStr};
+use std::mem::align_of;
+use std::os::unix::ffi::OsStrExt;
+use std::process::Command;
+use std::ptr::{copy_nonoverlapping, null_mut, write};
+use std::str;
+
+#[no_mangle]
+unsafe extern "C" fn getpwnam_r(
+    name: *const c_char,
+    pwd: *mut passwd,
+    buf: *mut c_char,
+    buflen: usize,
+    result: *mut *mut passwd,
+) -> c_int {
+    libc!(libc::getpwnam_r(name, pwd, buf, buflen, result));
+
+    let name = OsStr::from_bytes(CStr::from_ptr(name).to_bytes());
+    let mut command = Command::new("getent");
+    command.arg("passwd").arg(name);
+    getpw_r(command, pwd, buf, buflen, result)
+}
+
+#[no_mangle]
+unsafe extern "C" fn getpwuid_r(
+    uid: uid_t,
+    pwd: *mut passwd,
+    buf: *mut c_char,
+    buflen: usize,
+    result: *mut *mut passwd,
+) -> c_int {
+    libc!(libc::getpwuid_r(uid, pwd, buf, buflen, result));
+
+    let dec_int = DecInt::new(uid);
+    let name = OsStr::from_bytes(dec_int.as_bytes());
+    let mut command = Command::new("getent");
+    command.arg("passwd").arg(&name);
+    getpw_r(command, pwd, buf, buflen, result)
+}
+
+#[no_mangle]
+unsafe extern "C" fn getgrnam_r(
+    name: *const c_char,
+    grp: *mut group,
+    buf: *mut c_char,
+    buflen: usize,
+    result: *mut *mut group,
+) -> c_int {
+    libc!(libc::getgrnam_r(name, grp, buf, buflen, result));
+
+    let name = OsStr::from_bytes(CStr::from_ptr(name).to_bytes());
+    let mut command = Command::new("getent");
+    command.arg("group").arg(name);
+    getgr_r(command, grp, buf, buflen, result)
+}
+
+#[no_mangle]
+unsafe extern "C" fn getgrgid_r(
+    gid: gid_t,
+    grp: *mut group,
+    buf: *mut c_char,
+    buflen: usize,
+    result: *mut *mut group,
+) -> c_int {
+    libc!(libc::getgrgid_r(gid, grp, buf, buflen, result));
+
+    let dec_int = DecInt::new(gid);
+    let name = OsStr::from_bytes(dec_int.as_bytes());
+    let mut command = Command::new("getent");
+    command.arg("group").arg(&name);
+    getgr_r(command, grp, buf, buflen, result)
+}
+
+unsafe fn getpw_r(
+    command: Command,
+    pwd: *mut passwd,
+    buf: *mut c_char,
+    buflen: usize,
+    result: *mut *mut passwd,
+) -> c_int {
+    let mut command = command;
+    let output = match command.output() {
+        Ok(output) => output,
+        Err(_err) => {
+            *result = null_mut();
+            return libc::EIO;
+        }
+    };
+
+    match output.status.code() {
+        Some(0) => {}
+        Some(2) => {
+            // The username was not found.
+            *result = null_mut();
+            return 0;
+        }
+        Some(r) => panic!("unexpected exit status from `getent passwd`: {}", r),
+        None => {
+            *result = null_mut();
+            return libc::EIO;
+        }
+    }
+
+    let stdout = match str::from_utf8(&output.stdout) {
+        Ok(stdout) => stdout,
+        Err(_err) => return parse_error(result.cast()),
+    };
+    let stdout = match stdout.strip_suffix('\n') {
+        Some(stdout) => stdout,
+        None => return parse_error(result.cast()),
+    };
+
+    let mut parts = stdout.split(':');
+    let mut buf = buf;
+    let mut buflen = buflen;
+
+    let part = match parts.next() {
+        Some(part) => part,
+        None => return parse_error(result.cast()),
+    };
+    if part.len() > buflen {
+        return buffer_exhausted(result.cast());
+    }
+    let pw_name = buf;
+    copy_nonoverlapping(part.as_ptr(), buf.cast(), part.len());
+    buf = buf.add(part.len());
+    write(buf, 0);
+    buf = buf.add(1);
+    buflen -= part.len() + 1;
+
+    let part = match parts.next() {
+        Some(part) => part,
+        None => return parse_error(result.cast()),
+    };
+    if part.len() > buflen {
+        return buffer_exhausted(result.cast());
+    }
+    let pw_passwd = buf;
+    copy_nonoverlapping(part.as_ptr(), buf.cast(), part.len());
+    buf = buf.add(part.len());
+    write(buf, 0);
+    buf = buf.add(1);
+    buflen -= part.len() + 1;
+
+    let part = match parts.next() {
+        Some(part) => part,
+        None => return parse_error(result.cast()),
+    };
+    let pw_uid = match part.parse() {
+        Ok(pw_uid) => pw_uid,
+        Err(_err) => return parse_error(result.cast()),
+    };
+
+    let part = match parts.next() {
+        Some(part) => part,
+        None => return parse_error(result.cast()),
+    };
+    let pw_gid = match part.parse() {
+        Ok(pw_gid) => pw_gid,
+        Err(_err) => return parse_error(result.cast()),
+    };
+
+    let part = match parts.next() {
+        Some(part) => part,
+        None => return parse_error(result.cast()),
+    };
+    if part.len() > buflen {
+        return buffer_exhausted(result.cast());
+    }
+    let pw_gecos = buf;
+    copy_nonoverlapping(part.as_ptr(), buf.cast(), part.len());
+    buf = buf.add(part.len());
+    write(buf, 0);
+    buf = buf.add(1);
+    buflen -= part.len() + 1;
+
+    let part = match parts.next() {
+        Some(part) => part,
+        None => return parse_error(result.cast()),
+    };
+    if part.len() > buflen {
+        return buffer_exhausted(result.cast());
+    }
+    let pw_dir = buf;
+    copy_nonoverlapping(part.as_ptr(), buf.cast(), part.len());
+    buf = buf.add(part.len());
+    write(buf, 0);
+    buf = buf.add(1);
+    buflen -= part.len() + 1;
+
+    let part = match parts.next() {
+        Some(part) => part,
+        None => return parse_error(result.cast()),
+    };
+    if part.len() > buflen {
+        return buffer_exhausted(result.cast());
+    }
+    let pw_shell = buf;
+    copy_nonoverlapping(part.as_ptr(), buf.cast(), part.len());
+    buf = buf.add(part.len());
+    write(buf, 0);
+
+    write(
+        pwd,
+        passwd {
+            pw_name,
+            pw_passwd,
+            pw_uid,
+            pw_gid,
+            pw_gecos,
+            pw_dir,
+            pw_shell,
+        },
+    );
+    *result = pwd;
+    0
+}
+
+unsafe fn getgr_r(
+    command: Command,
+    grp: *mut group,
+    buf: *mut c_char,
+    buflen: usize,
+    result: *mut *mut group,
+) -> c_int {
+    let mut command = command;
+    let output = match command.output() {
+        Ok(output) => output,
+        Err(_err) => {
+            *result = null_mut();
+            return libc::EIO;
+        }
+    };
+
+    match output.status.code() {
+        Some(0) => {}
+        Some(2) => {
+            // The username was not found.
+            *result = null_mut();
+            return 0;
+        }
+        Some(r) => panic!("unexpected exit status from `getent group`: {}", r),
+        None => {
+            *result = null_mut();
+            return libc::EIO;
+        }
+    }
+
+    let stdout = match str::from_utf8(&output.stdout) {
+        Ok(stdout) => stdout,
+        Err(_err) => return parse_error(result.cast()),
+    };
+    let stdout = match stdout.strip_suffix('\n') {
+        Some(stdout) => stdout,
+        None => return parse_error(result.cast()),
+    };
+
+    let mut parts = stdout.split(':');
+    let mut buf = buf;
+    let mut buflen = buflen;
+
+    let part = match parts.next() {
+        Some(part) => part,
+        None => return parse_error(result.cast()),
+    };
+    if part.len() > buflen {
+        return buffer_exhausted(result.cast());
+    }
+    let gr_name = buf;
+    copy_nonoverlapping(part.as_ptr(), buf.cast(), part.len());
+    buf = buf.add(part.len());
+    write(buf, 0);
+    buf = buf.add(1);
+    buflen -= part.len() + 1;
+
+    let part = match parts.next() {
+        Some(part) => part,
+        None => return parse_error(result.cast()),
+    };
+    if part.len() > buflen {
+        return buffer_exhausted(result.cast());
+    }
+    let gr_passwd = buf;
+    copy_nonoverlapping(part.as_ptr(), buf.cast(), part.len());
+    buf = buf.add(part.len());
+    write(buf, 0);
+    buf = buf.add(1);
+    buflen -= part.len() + 1;
+
+    let part = match parts.next() {
+        Some(part) => part,
+        None => return parse_error(result.cast()),
+    };
+    let gr_gid = match part.parse() {
+        Ok(pw_gid) => pw_gid,
+        Err(_err) => return parse_error(result.cast()),
+    };
+
+    let part = match parts.next() {
+        Some(part) => part,
+        None => return parse_error(result.cast()),
+    };
+    if part.len() > buflen {
+        return buffer_exhausted(result.cast());
+    }
+
+    let num_members = if part.is_empty() {
+        0
+    } else {
+        part.split(',').count()
+    };
+    let pad = align_of::<*const c_char>() - (buf.addr()) % align_of::<*const c_char>();
+    buf = buf.add(pad);
+    buflen -= pad;
+    let gr_mem = buf.cast::<*mut c_char>();
+    buf = gr_mem.add(num_members + 1).cast::<c_char>();
+    buflen -= buf.addr() - gr_mem.addr();
+
+    let mut cur_mem = gr_mem;
+    if num_members != 0 {
+        for member in part.split(',') {
+            *cur_mem = buf;
+            cur_mem = cur_mem.add(1);
+            copy_nonoverlapping(member.as_ptr(), buf.cast(), member.len());
+            buf = buf.add(member.len());
+            write(buf, 0);
+            buf = buf.add(1);
+            buflen -= member.len() + 1;
+        }
+    }
+    write(cur_mem, null_mut());
+
+    write(
+        grp,
+        group {
+            gr_name,
+            gr_passwd,
+            gr_gid,
+            gr_mem,
+        },
+    );
+    *result = grp;
+    0
+}
+
+#[cold]
+unsafe fn buffer_exhausted(result: *mut *mut c_void) -> c_int {
+    *result = null_mut();
+    libc::ERANGE
+}
+
+#[cold]
+unsafe fn parse_error(result: *mut *mut c_void) -> c_int {
+    *result = null_mut();
+    libc::EIO
+}

--- a/c-gull/src/printf.rs
+++ b/c-gull/src/printf.rs
@@ -1,0 +1,140 @@
+//! The `printf` family of functions.
+//!
+//! This code is highly experimental.
+//!
+//! This uses the `printf_compat` crate, which [has differences with glibc].
+//!
+//! The `fprintf` implementation doesn't have a real `FILE` type yet.
+//!
+//! Caution is indicated.
+//!
+//! [has differences with glibc]: https://docs.rs/printf-compat/0.1.1/printf_compat/output/fn.fmt_write.html#differences
+
+use libc::{c_char, c_int, c_void};
+use printf_compat::{format, output};
+use rustix::fd::{FromRawFd, IntoRawFd};
+use std::cmp::min;
+use std::ffi::CStr;
+use std::ffi::VaList;
+use std::io::{stderr as rust_stderr, stdout as rust_stdout, Write};
+use std::ptr::copy_nonoverlapping;
+
+#[no_mangle]
+unsafe extern "C" fn puts(s: *const c_char) -> c_int {
+    libc!(libc::puts(s));
+
+    match rust_stdout().write_all(CStr::from_ptr(s).to_bytes()) {
+        Ok(()) => 1,
+        Err(_err) => libc::EOF,
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn printf(fmt: *const c_char, mut args: ...) -> c_int {
+    let va_list = args.as_va_list();
+    vprintf(fmt, va_list)
+}
+
+#[no_mangle]
+unsafe extern "C" fn vprintf(fmt: *const c_char, va_list: VaList) -> c_int {
+    //libc!(libc::vprintf(fmt, va_list));
+
+    format(fmt, va_list, output::io_write(&mut rust_stdout()))
+}
+
+#[no_mangle]
+unsafe extern "C" fn sprintf(ptr: *mut c_char, fmt: *const c_char, mut args: ...) -> c_int {
+    let va_list = args.as_va_list();
+    vsprintf(ptr, fmt, va_list)
+}
+
+#[no_mangle]
+unsafe extern "C" fn vsprintf(ptr: *mut c_char, fmt: *const c_char, va_list: VaList) -> c_int {
+    //libc!(libc::vsprintf(ptr, fmt, va_list));
+
+    let mut out = String::new();
+    let num_bytes = format(fmt, va_list, output::fmt_write(&mut out));
+    copy_nonoverlapping(out.as_ptr(), ptr.cast(), num_bytes as usize);
+    num_bytes
+}
+
+#[no_mangle]
+unsafe extern "C" fn snprintf(
+    ptr: *mut c_char,
+    len: usize,
+    fmt: *const c_char,
+    mut args: ...
+) -> c_int {
+    let va_list = args.as_va_list();
+    vsnprintf(ptr, len, fmt, va_list)
+}
+
+#[no_mangle]
+unsafe extern "C" fn vsnprintf(
+    ptr: *mut c_char,
+    len: usize,
+    fmt: *const c_char,
+    va_list: VaList,
+) -> c_int {
+    //libc!(libc::vsnprintf(ptr, len, fmt, va_list));
+
+    let mut out = String::new();
+    let num_bytes = format(fmt, va_list, output::fmt_write(&mut out));
+
+    if num_bytes >= 0 {
+        out.push('\0');
+
+        copy_nonoverlapping(out.as_ptr(), ptr.cast(), min(num_bytes as usize + 1, len));
+    }
+
+    num_bytes
+}
+
+#[no_mangle]
+unsafe extern "C" fn dprintf(fd: c_int, fmt: *const c_char, mut args: ...) -> c_int {
+    let va_list = args.as_va_list();
+    vdprintf(fd, fmt, va_list)
+}
+
+#[no_mangle]
+unsafe extern "C" fn vdprintf(fd: c_int, fmt: *const c_char, va_list: VaList) -> c_int {
+    //libc!(libc::vdprintf(fd, fmt, va_list));
+
+    let mut tmp = std::fs::File::from_raw_fd(fd);
+    let num_bytes = format(fmt, va_list, output::io_write(&mut tmp));
+    let _ = tmp.into_raw_fd();
+    num_bytes
+}
+
+#[no_mangle]
+unsafe extern "C" fn fprintf(file: *mut c_void, fmt: *const c_char, mut args: ...) -> c_int {
+    let va_list = args.as_va_list();
+    vfprintf(file, fmt, va_list)
+}
+
+#[no_mangle]
+unsafe extern "C" fn vfprintf(file: *mut c_void, fmt: *const c_char, va_list: VaList) -> c_int {
+    //libc!(libc::vfprintf(file, fmt, va_list));
+
+    if file == stdout {
+        vprintf(fmt, va_list)
+    } else if file == stderr {
+        format(fmt, va_list, output::io_write(&mut rust_stderr()))
+    } else {
+        unimplemented!("vfprintf")
+    }
+}
+
+#[no_mangle]
+#[allow(non_upper_case_globals)]
+static mut stdin: *mut c_void = unsafe { THE_STDIN.as_mut_ptr().cast() };
+#[no_mangle]
+#[allow(non_upper_case_globals)]
+static mut stdout: *mut c_void = unsafe { THE_STDOUT.as_mut_ptr().cast() };
+#[no_mangle]
+#[allow(non_upper_case_globals)]
+static mut stderr: *mut c_void = unsafe { THE_STDERR.as_mut_ptr().cast() };
+
+static mut THE_STDIN: [u8; 1] = [0];
+static mut THE_STDOUT: [u8; 1] = [1];
+static mut THE_STDERR: [u8; 1] = [2];

--- a/c-gull/src/rand48.rs
+++ b/c-gull/src/rand48.rs
@@ -1,0 +1,69 @@
+use libc::{c_double, c_long, c_ushort};
+use rand::distributions::{Standard, Uniform};
+use rand::{thread_rng, Rng};
+
+#[no_mangle]
+unsafe extern "C" fn drand48() -> c_double {
+    //libc!(libc::drand48());
+
+    thread_rng().sample(Standard)
+}
+
+#[no_mangle]
+unsafe extern "C" fn erand48(_xsubi: &[c_ushort; 3]) -> c_double {
+    //libc!(libc::erand48(xsubi));
+
+    unimplemented!("erand48")
+}
+
+#[no_mangle]
+unsafe extern "C" fn lrand48() -> c_long {
+    //libc!(libc::lrand48());
+
+    thread_rng().sample(Uniform::new_inclusive(0, i32::MAX as c_long))
+}
+
+#[no_mangle]
+unsafe extern "C" fn nrand48(_xsubi: &[c_ushort; 3]) -> c_long {
+    //libc!(libc::nrand48(xsubi));
+
+    unimplemented!("nrand48")
+}
+
+#[no_mangle]
+unsafe extern "C" fn mrand48() -> c_long {
+    //libc!(libc::mrand48());
+
+    thread_rng().sample(Uniform::new_inclusive(
+        i32::MIN as c_long,
+        i32::MAX as c_long,
+    ))
+}
+
+#[no_mangle]
+unsafe extern "C" fn jrand48(_xsubi: &[c_ushort; 3]) -> c_long {
+    //libc!(libc::jrand48(xsubi));
+
+    unimplemented!("jrand48")
+}
+
+#[no_mangle]
+unsafe extern "C" fn srand48(_seedval: c_long) {
+    //libc!(libc::srand48(seedval));
+
+    unimplemented!("srand48")
+}
+
+#[no_mangle]
+unsafe extern "C" fn seed48(_seed16v: &[c_ushort; 3]) -> *mut c_ushort {
+    //libc!(libc::seed48(seed16v));
+
+    unimplemented!("seed48")
+}
+
+#[no_mangle]
+unsafe extern "C" fn lcong48(_param: &[c_ushort; 7]) {
+    //libc!(libc::lcong48(param));
+
+    unimplemented!("lcong48")
+}

--- a/c-gull/src/strtod.rs
+++ b/c-gull/src/strtod.rs
@@ -1,0 +1,15 @@
+use libc::{c_char, c_double, c_float};
+
+#[no_mangle]
+unsafe extern "C" fn strtof(nptr: *const c_char, endptr: *mut *mut c_char) -> c_float {
+    libc!(libc::strtof(nptr, endptr));
+
+    unimplemented!("strtof")
+}
+
+#[no_mangle]
+unsafe extern "C" fn strtod(nptr: *const c_char, endptr: *mut *mut c_char) -> c_double {
+    libc!(libc::strtod(nptr, endptr));
+
+    unimplemented!("strtod")
+}

--- a/c-gull/src/strtol.rs
+++ b/c-gull/src/strtol.rs
@@ -1,0 +1,41 @@
+use libc::{c_char, c_int, c_long, c_longlong, c_ulong, c_ulonglong};
+
+#[no_mangle]
+unsafe extern "C" fn strtol(nptr: *const c_char, endptr: *mut *mut c_char, base: c_int) -> c_long {
+    libc!(libc::strtol(nptr, endptr, base));
+
+    unimplemented!("strtol")
+}
+
+#[no_mangle]
+unsafe extern "C" fn strtoll(
+    _nptr: *const c_char,
+    _endptr: *mut *mut c_char,
+    _base: c_int,
+) -> c_longlong {
+    //libc!(libc::strtoll(nptr, endptr, base));
+
+    unimplemented!("strtoll")
+}
+
+#[no_mangle]
+unsafe extern "C" fn strtoul(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    base: c_int,
+) -> c_ulong {
+    libc!(libc::strtoul(nptr, endptr, base));
+
+    unimplemented!("strtoul")
+}
+
+#[no_mangle]
+unsafe extern "C" fn strtoull(
+    _nptr: *const c_char,
+    _endptr: *mut *mut c_char,
+    _base: c_int,
+) -> c_ulonglong {
+    //libc!(libc::strtoull(nptr, endptr, base));
+
+    unimplemented!("strtoull")
+}

--- a/c-gull/src/time.rs
+++ b/c-gull/src/time.rs
@@ -1,0 +1,236 @@
+//! Time and date conversion routines.
+//!
+//! This code is highly experimental and contains some FIXMEs.
+
+use errno::{set_errno, Errno};
+use libc::{c_char, time_t, tm};
+use std::ptr::{null_mut, write};
+use tz::error::{TzError, TzFileError, TzStringError};
+use tz::{DateTime, LocalTimeType, TimeZone};
+
+// These things aren't really thread-safe, but they're implementing C ABIs and
+// the C rule is, it's up to the user to ensure that none of the bad things
+// happen.
+struct SyncTzName([*mut c_char; 2]);
+unsafe impl Sync for SyncTzName {}
+
+struct SyncTm(tm);
+unsafe impl Sync for SyncTm {}
+
+#[no_mangle]
+static mut tzname: SyncTzName = SyncTzName([null_mut(), null_mut()]);
+
+#[no_mangle]
+unsafe extern "C" fn gmtime(time: *const time_t) -> *mut tm {
+    libc!(libc::gmtime(time));
+
+    static mut TM: SyncTm = SyncTm(blank_tm());
+    gmtime_r(time, &mut TM.0)
+}
+
+#[no_mangle]
+unsafe extern "C" fn gmtime_r(time: *const time_t, result: *mut tm) -> *mut tm {
+    libc!(libc::gmtime_r(time, result));
+
+    let utc_time_type = LocalTimeType::utc();
+
+    let date_time = match DateTime::from_timespec_and_local((*time).into(), 0, utc_time_type) {
+        Ok(date_time) => date_time,
+        Err(_err) => {
+            set_errno(Errno(libc::EIO));
+            return null_mut();
+        }
+    };
+
+    write(result, date_time_to_tm(date_time, utc_time_type));
+
+    result
+}
+
+#[no_mangle]
+unsafe extern "C" fn localtime(time: *const time_t) -> *mut tm {
+    libc!(libc::localtime(time));
+
+    static mut TM: SyncTm = SyncTm(blank_tm());
+    localtime_r(time, &mut TM.0)
+}
+
+#[no_mangle]
+unsafe extern "C" fn localtime_r(time: *const time_t, result: *mut tm) -> *mut tm {
+    libc!(libc::localtime_r(time, result));
+
+    let time_zone_local = match TimeZone::local() {
+        Ok(time_zone_local) => time_zone_local,
+        Err(err) => {
+            set_errno(Errno(tz_error_to_errno(err)));
+            return null_mut();
+        }
+    };
+
+    let local_time_type = match time_zone_local.find_local_time_type((*time).into()) {
+        Ok(local_time_type) => local_time_type,
+        Err(_err) => {
+            set_errno(Errno(libc::EIO));
+            return null_mut();
+        }
+    };
+
+    let date_time = match DateTime::from_timespec_and_local((*time).into(), 0, *local_time_type) {
+        Ok(date_time) => date_time,
+        Err(_err) => {
+            set_errno(Errno(libc::EIO));
+            return null_mut();
+        }
+    };
+
+    write(result, date_time_to_tm(date_time, *local_time_type));
+
+    result
+}
+
+#[no_mangle]
+unsafe extern "C" fn mktime(tm: *mut tm) -> time_t {
+    libc!(libc::mktime(tm));
+
+    let time_zone_local = match TimeZone::local() {
+        Ok(time_zone_local) => time_zone_local,
+        Err(err) => {
+            set_errno(Errno(tz_error_to_errno(err)));
+            return -1;
+        }
+    };
+
+    let current_local_time_type = match time_zone_local.find_current_local_time_type() {
+        Ok(local_time_type) => local_time_type,
+        Err(_err) => {
+            set_errno(Errno(libc::EIO));
+            return -1;
+        }
+    };
+
+    let tm_year = (*tm).tm_year;
+    let tm_mon: u8 = match (*tm).tm_mon.try_into() {
+        Ok(tm_mon) => tm_mon,
+        Err(_err) => {
+            set_errno(Errno(libc::EOVERFLOW));
+            return -1;
+        }
+    };
+    let tm_mday = match (*tm).tm_mday.try_into() {
+        Ok(tm_mday) => tm_mday,
+        Err(_err) => {
+            set_errno(Errno(libc::EOVERFLOW));
+            return -1;
+        }
+    };
+    let tm_hour = match (*tm).tm_hour.try_into() {
+        Ok(tm_hour) => tm_hour,
+        Err(_err) => {
+            set_errno(Errno(libc::EOVERFLOW));
+            return -1;
+        }
+    };
+    let tm_min = match (*tm).tm_min.try_into() {
+        Ok(tm_min) => tm_min,
+        Err(_err) => {
+            set_errno(Errno(libc::EOVERFLOW));
+            return -1;
+        }
+    };
+    let tm_sec = match (*tm).tm_sec.try_into() {
+        Ok(tm_sec) => tm_sec,
+        Err(_err) => {
+            set_errno(Errno(libc::EOVERFLOW));
+            return -1;
+        }
+    };
+
+    // FIXME: What should we do with tm.tm_isdst?
+
+    // Create a new date time.
+    let date_time = match DateTime::new(
+        tm_year + 1900,
+        tm_mon + 1,
+        tm_mday,
+        tm_hour,
+        tm_min,
+        tm_sec,
+        0,
+        *current_local_time_type,
+    ) {
+        Ok(date_time) => date_time,
+        Err(_err) => {
+            set_errno(Errno(libc::EIO));
+            return -1;
+        }
+    };
+
+    let result = date_time.unix_time();
+
+    set_tzname(current_local_time_type);
+
+    write(tm, date_time_to_tm(date_time, *current_local_time_type));
+
+    match result.try_into() {
+        Ok(result) => result,
+        Err(_err) => {
+            set_errno(Errno(libc::EOVERFLOW));
+            -1
+        }
+    }
+}
+
+fn date_time_to_tm(date_time: DateTime, local_time_type: LocalTimeType) -> tm {
+    tm {
+        tm_year: date_time.year() - 1900,
+        tm_mon: (date_time.month() - 1).into(),
+        tm_mday: date_time.month_day().into(),
+        tm_hour: date_time.hour().into(),
+        tm_min: date_time.minute().into(),
+        tm_sec: date_time.second().into(),
+        tm_wday: date_time.week_day().into(),
+        tm_yday: date_time.year_day().into(),
+        tm_isdst: if local_time_type.is_dst() { 1 } else { 0 },
+        tm_gmtoff: local_time_type.ut_offset().into(),
+        tm_zone: b"FIXME(c-gull)\0".as_ptr().cast(),
+    }
+}
+
+const fn blank_tm() -> tm {
+    tm {
+        tm_year: 0,
+        tm_mon: 0,
+        tm_mday: 0,
+        tm_hour: 0,
+        tm_min: 0,
+        tm_sec: 0,
+        tm_wday: 0,
+        tm_yday: 0,
+        tm_isdst: -1,
+        tm_gmtoff: 0,
+        tm_zone: null_mut(),
+    }
+}
+
+unsafe fn set_tzname(_time_zone_local: &LocalTimeType) {
+    tzname.0[0] = "FIXME(c-gull)\0".as_ptr() as _;
+    tzname.0[1] = "FIXME(c-gull)\0".as_ptr() as _;
+}
+
+fn tz_error_to_errno(err: TzError) -> i32 {
+    match err {
+        TzError::IoError(err) => err.raw_os_error().unwrap_or(libc::EIO),
+        TzError::TzFileError(TzFileError::IoError(err)) => err.raw_os_error().unwrap_or(libc::EIO),
+        TzError::TzStringError(TzStringError::IoError(err)) => {
+            err.raw_os_error().unwrap_or(libc::EIO)
+        }
+        _ => libc::EIO,
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn timegm(tm: *mut tm) -> time_t {
+    libc!(libc::timegm(tm));
+
+    unimplemented!("timegm")
+}

--- a/c-gull/src/use_libc.rs
+++ b/c-gull/src/use_libc.rs
@@ -23,7 +23,7 @@ macro_rules! checked_cast {
 }
 
 /// A macro for ensuring that the `libc` crate signature for a function matches
-/// the signature that c-scape is using.
+/// the signature that our implementation of it is using.
 ///
 /// # Example
 ///
@@ -47,7 +47,7 @@ macro_rules! libc {
     };
 }
 
-/// This is used to check that a `c-scape` type matches the layout of the
+/// This is used to check that our type definition matches the layout of the
 /// corresponding libc type.
 #[cfg(all(target_vendor = "mustang", feature = "threads"))]
 macro_rules! libc_type {

--- a/c-gull/src/use_libc.rs
+++ b/c-gull/src/use_libc.rs
@@ -1,0 +1,100 @@
+//! Utilities to check against C signatures.
+
+#![allow(unused_macros)]
+#![allow(dead_code)]
+
+/// Cast the given pointer to another type, similarly to calling `cast()` on
+/// it, while verifying that the layout of the pointee stays the same after the
+/// cast.
+macro_rules! checked_cast {
+    ($ptr:ident) => {{
+        let target_ptr = $ptr.cast();
+        let target = crate::use_libc::Pad::new(core::ptr::read(target_ptr));
+
+        // Uses the fact that the compiler checks for size equality,
+        // when transmuting between types.
+        let size_check = core::mem::transmute(core::ptr::read($ptr));
+        target.compare_size(size_check);
+        let align_check = core::mem::transmute(crate::use_libc::Pad::new(core::ptr::read($ptr)));
+        target.compare_alignment(align_check);
+
+        target_ptr
+    }};
+}
+
+/// A macro for ensuring that the `libc` crate signature for a function matches
+/// the signature that c-scape is using.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// #[no_mangle]
+/// unsafe extern "C" fn strlen(s: *const c_char) -> usize {
+///    libc!(libc::strlen(s));
+///    ...
+/// ```
+///
+/// This will elicit a compile-time error if the signature doesn't match.
+macro_rules! libc {
+    ($e:expr) => {
+        #[allow(unreachable_code)]
+        #[allow(clippy::diverging_sub_expression)]
+        if false {
+            #[allow(unused_imports)]
+            use crate::use_libc::*;
+            return $e;
+        }
+    };
+}
+
+/// This is used to check that a `c-scape` type matches the layout of the
+/// corresponding libc type.
+#[cfg(all(target_vendor = "mustang", feature = "threads"))]
+macro_rules! libc_type {
+    ($name:ident, $libc:ident) => {
+        #[cfg(test)]
+        static_assertions::const_assert_eq!(
+            core::mem::size_of::<$name>(),
+            core::mem::size_of::<libc::$libc>()
+        );
+        #[cfg(test)]
+        static_assertions::const_assert_eq!(
+            core::mem::align_of::<$name>(),
+            core::mem::align_of::<libc::$libc>()
+        );
+    };
+}
+
+/// A struct that adds `align_of<T>` padding bytes to type `T`.
+///
+/// Based on the rules of C struct alignment:
+/// * `align_of<Pad<T>> == max(align_of<T>, align_of<u8>) == align_of<T>`
+/// * `size_of<Pad<T>> / align_of<Pad<T>> == ciel( (size_of<T> + size_of<u8>) /
+///   align_of<Pad<T>>)`
+/// * `size_of<T> % align_of<T> == 0`
+///
+/// Therefore `size_of<Pad<T>> == size_of<T> + align_of<T>`.
+#[repr(C)]
+pub(crate) struct Pad<T> {
+    field: T,
+    force_padding: u8,
+}
+
+impl<T> Pad<T> {
+    pub unsafe fn new(v: T) -> Self {
+        Pad {
+            field: v,
+            force_padding: 0,
+        }
+    }
+
+    /// Used to check that `size_of<T> == size_of<U>` with `transmute`.
+    pub fn compare_size(&self, _v: T) {}
+
+    /// Used to check that `size_of<Pad<T>> == size_of<Pad<U>>` with
+    /// `transmute`.
+    ///
+    /// Since `size_of<Pad<T>> == size_of<T> + align_of<T>`,
+    /// if `size_of<T> == size_of<U>` then `align_of<T> == align_of<U>`.
+    pub fn compare_alignment(&self, _pad: Pad<T>) {}
+}

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.5.1"
 authors = [
     "Dan Gohman <dev@sunfishcode.online>",
 ]
-description = "A libc implementation in Rust"
+description = "A libc bottom-half implementation in Rust"
 documentation = "https://docs.rs/c-scape"
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 repository = "https://github.com/sunfishcode/mustang"

--- a/c-scape/README.md
+++ b/c-scape/README.md
@@ -2,7 +2,7 @@
   <h1><code>c-scape</code></h1>
 
   <p>
-    <strong>A libc implementation in Rust</strong>
+    <strong>A layer underneath c-gull</strong>
   </p>
 
   <p>
@@ -13,50 +13,8 @@
   </p>
 </div>
 
-c-scape is a libc implementation. It is an implementation of the ABI described
-by the [libc] crate.
+c-scape is a layer underneath [c-gull]. It provides a subset of libc features,
+containing only features that don't require Rust's `std` to implement. This
+allows it to be used by `std` itself.
 
-It is implemented in terms of crates written in Rust, such as [rustix],
-[origin], [sync-resolve], [libm], [realpath-ext], and [memchr].
-
-Currently it only supports `*-*-linux-gnu` ABIs, though other ABIs could be
-added in the future. And currently this mostly focused on features needed by
-Rust programs, so it doesn't have many C-idiomatic things like `printf` yet, but
-they could be added in the future.
-
-The goal is to have very little code in c-scape itself, by factoring out all of
-the significant functionality into independent crates with more Rust-idiomatic
-APIs, with c-scape just wrapping those APIs to implement the C ABIs.
-
-This is currently experimental, incomplete, and some things aren't optimized.
-
-This is part of the [Mustang] project, building Rust programs written entirely
-in Rust.
-
-## Using c-scape in non-mustang programs
-
-c-scape can also be used as a drop-in (partial) libc replacement in non-mustang
-builds, provided you're using nightly Rust. To use it, just change your typical
-libc dependency in Cargo.toml to this:
-
-```toml
-libc = { version = "<c-scape version>", package = "c-scape" }
-```
-
-and c-scape will replace as many of the system libc implementation with its own
-implementations as it can. In particular, it can't replace `malloc` or any of
-the pthread functions in this configuration, but it can replace many other
-things.
-
-See the [libc-replacement example] for more details.
-
-[libc-replacement example]: https://github.com/sunfishcode/mustang/blob/main/test-crates/libc-replacement/README.md
-[Mustang]: https://github.com/sunfishcode/mustang/
-[rustix]: https://crates.io/crates/rustix
-[origin]: https://crates.io/crates/origin
-[sync-resolve]: https://crates.io/crates/sync-resolve
-[libm]: https://crates.io/crates/libm
-[libc]: https://crates.io/crates/libc
-[realpath-ext]: https://crates.io/crates/realpath-ext
-[memchr]: https://crates.io/crates/memchr
-[mustang]: https://crates.io/crates/mustang
+[c-gull]: https://crates.io/crates/c-gull

--- a/c-scape/src/at_fork.rs
+++ b/c-scape/src/at_fork.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use origin::sync::Mutex;
 
 /// Functions registered with `at_fork`.

--- a/c-scape/src/fs/opendir.rs
+++ b/c-scape/src/fs/opendir.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use core::ffi::CStr;
 use rustix::fd::{BorrowedFd, FromRawFd, IntoRawFd};
 use rustix::fs::{cwd, Mode, OFlags};

--- a/c-scape/src/fs/readlink.rs
+++ b/c-scape/src/fs/readlink.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::ffi::CStr;
 use rustix::fd::BorrowedFd;
 

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![no_std]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![no_builtins] // don't let LLVM optimize our `memcpy` into a `memcpy` call
 #![feature(thread_local)] // for `__errno_location`
@@ -347,6 +348,7 @@ unsafe extern "C" fn raise(_sig: c_int) -> c_int {
 
 // nss
 
+#[cfg(not(feature = "std"))] // Avoid conflicting with c-gull's more complete `getpwuid_r`.
 #[cfg(not(target_os = "wasi"))]
 #[no_mangle]
 unsafe extern "C" fn getpwuid_r() {

--- a/c-scape/src/threads/mod.rs
+++ b/c-scape/src/threads/mod.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use core::convert::TryInto;
 use core::ffi::c_void;
 use core::ptr::{self, null, null_mut};

--- a/c-scape/src/use_libc.rs
+++ b/c-scape/src/use_libc.rs
@@ -1,5 +1,8 @@
 //! Utilities to check against C signatures.
 
+#![allow(unused_macros)]
+#![allow(dead_code)]
+
 /// Cast the given pointer to another type, similarly to calling `cast()` on
 /// it, while verifying that the layout of the pointee stays the same after the
 /// cast.
@@ -20,7 +23,7 @@ macro_rules! checked_cast {
 }
 
 /// A macro for ensuring that the `libc` crate signature for a function matches
-/// the signature that c-scape is using.
+/// the signature that our implementation of it is using.
 ///
 /// # Example
 ///
@@ -44,7 +47,7 @@ macro_rules! libc {
     };
 }
 
-/// This is used to check that a `c-scape` type matches the layout of the
+/// This is used to check that our type definition matches the layout of the
 /// corresponding libc type.
 #[cfg(all(target_vendor = "mustang", feature = "threads"))]
 macro_rules! libc_type {

--- a/mustang/Cargo.toml
+++ b/mustang/Cargo.toml
@@ -33,7 +33,7 @@ features = [
 
 [target.'cfg(target_vendor = "mustang")'.dependencies]
 origin = { path = "../origin", default-features = false, version = "^0.5.0" }
-c-scape = { path = "../c-scape", version = "^0.5.0" }
+c-gull = { path = "../c-gull", version = "^0.5.0" }
 
 # A general-purpose `global_allocator` implementation.
 dlmalloc = { version = "0.2", features = ["global"], optional = true }
@@ -43,4 +43,7 @@ wee_alloc = { version = "0.4", optional = true }
 [features]
 default = ["default-alloc", "threads"]
 default-alloc = ["dlmalloc"]
-threads = ["origin/threads", "c-scape/threads"]
+threads = ["origin/threads", "c-gull/threads"]
+env_logger = ["origin/env_logger"]
+log = ["origin/log"]
+max_level_off = ["origin/max_level_off"]

--- a/mustang/src/lib.rs
+++ b/mustang/src/lib.rs
@@ -26,7 +26,7 @@ macro_rules! can_run_this {
 }
 
 #[cfg(target_vendor = "mustang")]
-extern crate c_scape;
+extern crate c_gull;
 #[cfg(target_vendor = "mustang")]
 extern crate origin;
 #[cfg(not(target_arch = "arm"))]

--- a/test-crates/libc-replacement/Cargo.toml
+++ b/test-crates/libc-replacement/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 # Ordinarily, one would use libc like this:
 #libc = "0.2"
 
-# But in this example, we use c-scape instead of libc:
-libc = { path = "../../c-scape", package = "c-scape" }
+# But in this example, we use c-gull instead of libc:
+libc = { path = "../../c-gull", package = "c-gull" }
 
 # This is just an example crate, and not part of the mustang workspace.
 [workspace]

--- a/test-crates/libc-replacement/README.md
+++ b/test-crates/libc-replacement/README.md
@@ -1,14 +1,14 @@
-This crate demonstrates the use of c-scape as a libc replacement, in
-non-mustang builds. In mustang builds, c-scape is the only option :-).
+This crate demonstrates the use of c-gull as a libc replacement, in
+non-mustang builds. In mustang builds, c-gull is the only option :-).
 
-c-scape re-exports libc's API, so it can be used as a drop-in replacement.
+c-gull re-exports libc's API, so it can be used as a drop-in replacement.
 
 This line:
 
 ```toml
-libc = { path = "../../c-scape", package = "c-scape" }
+libc = { path = "../../c-gull", package = "c-gull" }
 ```
 
-tells cargo to use c-scape in place of libc. In a non-mustang configuration,
+tells cargo to use c-gull in place of libc. In a non-mustang configuration,
 it doesn't replace the malloc, pthread, or getauxval functions, but it replaces
 everything it can, such as the `getpid` function in the example.

--- a/test-crates/libc-replacement/src/main.rs
+++ b/test-crates/libc-replacement/src/main.rs
@@ -1,3 +1,4 @@
 fn main() {
     println!("Hello, world! pid={}", unsafe { libc::getpid() });
+    unsafe { libc::printf("Hello world with printf! gid=%u\n\0".as_ptr().cast(), libc::getuid()); }
 }

--- a/test-crates/mustang-macro-does-nothing/README.md
+++ b/test-crates/mustang-macro-does-nothing/README.md
@@ -9,15 +9,16 @@ mustang-macro-does-nothing v0.0.0 (mustang/test-crates/mustang-macro-does-nothin
 ```
 
 When compiled for a mustang target, it depends on nightly Rust and it has the
-c-scape and origin dependencies:
+c-gull and origin dependencies:
 
 ```
 $ cargo tree --target=x86_64-mustang-linux-gnu
 mustang-macro-does-nothing v0.0.0 (mustang/test-crates/mustang-macro-does-nothing)
-└── mustang v0.4.1 (/mustang/mustang)
-    ├── c-scape v0.4.1 (mustang/c-scape)
-    │   ├── errno v0.2.8
-    │   │   └── libc v0.2.126
-    │   ├── libc v0.2.126
+└── mustang v0.5.1 (mustang/mustang)
+    ├── c-gull v0.5.1 (mustang/c-gull)
+    │   ├── c-scape v0.5.1 (mustang/c-scape)
+    │   │   ├── errno v0.2.8
+    │   │   │   └── libc v0.2.126
+    │   │   ├── libc v0.2.126
 ...
 ```


### PR DESCRIPTION
The relationship between c-scape and c-gull is:
 - c-gull: uses std and c-scape.
 - c-scape: does not use std.

This means c-scape can be used by std, and c-gull can't be. But it also
means that c-gull can easily implement many more C features. This PR adds:
 - timezone functions using the tz-rs crate
 - stdio functions using the printf-compat crate
 - random functions using the rand crate
 - nss functions using the getent command

c-gull is extraordinarily experimental.