### PR TITLE
Remove the "raw_dtors" feature.

### DIFF
--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -37,7 +37,7 @@ once_cell = "1.8.0"
 
 [features]
 default = ["threads", "resolve", "net"]
-threads = ["origin/threads", "origin/raw_dtors", "origin/set_thread_id"]
+threads = ["origin/threads", "origin/set_thread_id"]
 resolve = ["sync-resolve", "std"]
 std = ["rustix/std"]
 net = []

--- a/c-scape/src/threads/mod.rs
+++ b/c-scape/src/threads/mod.rs
@@ -701,7 +701,7 @@ unsafe extern "C" fn __cxa_thread_atexit_impl(
     _dso_symbol: *mut c_void,
 ) -> c_int {
     // TODO: libc!(libc::__cxa_thread_atexit_impl(func, obj, _dso_symbol));
-    origin::at_thread_exit_raw(func, obj);
+    origin::at_thread_exit(Box::new(move || func(obj)));
     0
 }
 

--- a/origin/Cargo.toml
+++ b/origin/Cargo.toml
@@ -16,7 +16,6 @@ rustix = { version = "0.35.6", default-features = false, features = ["mm", "thre
 bitflags = "1.3.0"
 memoffset = { version = "0.6.4", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
-tinyvec = { version = "1.5.1", default-features = false, optional = true }
 lock_api = { version = "0.4.7", features = ["nightly"] }
 
 # Optional logging backend. You can use any external logger, but using this
@@ -35,7 +34,6 @@ compiler_builtins = { version = '0.1.49', optional = true }
 [features]
 default = ["std", "threads", "log"]
 std = ["rustix/std", "linux-raw-sys/std"]
-raw_dtors = ["tinyvec"]
 set_thread_id = []
 rustc-dep-of-std = [
     "core",

--- a/origin/src/lib.rs
+++ b/origin/src/lib.rs
@@ -30,8 +30,6 @@ mod threads;
 mod arch;
 
 pub use program::{at_exit, exit, exit_immediately};
-#[cfg(feature = "raw_dtors")]
-pub use threads::at_thread_exit_raw;
 #[cfg(feature = "threads")]
 #[cfg(feature = "set_thread_id")]
 pub use threads::set_current_thread_id_after_a_fork;

--- a/origin/src/threads_via_pthreads.rs
+++ b/origin/src/threads_via_pthreads.rs
@@ -136,23 +136,6 @@ pub fn at_thread_exit(func: Box<dyn FnOnce()>) {
     }
 }
 
-/// Registers a raw `unsafe extern "C"` function to call when the current
-/// thread exits.
-///
-/// This function does not perform dynamic allocations. It only supports
-/// a fixed number of destructors. And it can only be called before any
-/// destructors are registered with [`at_thread_exit`].
-///
-/// # Safety
-///
-/// This arranges for `func` to be called, and passed `obj`, when the thread
-/// exits.
-#[cfg(feature = "raw_dtors")]
-#[doc(hidden)]
-pub unsafe fn at_thread_exit_raw(func: unsafe extern "C" fn(*mut c_void), obj: *mut c_void) {
-    assert_eq!(__cxa_thread_atexit_impl(func, obj, dso_handle()), 0);
-}
-
 /// Creates a new thread.
 ///
 /// `fn_` is called on the new thread.


### PR DESCRIPTION
This was needed when locks were implemented with parking_lot due to
parking_lot doing allocation in its locking functions. With the new
futex locks, there is no allocation, and we can just use the regular
`at_thread_exit` instead of `at_thread_exit_raw` and its complex and
problematic safety conditions.