### PR TITLE
Call the TLS destructors on `exit`.

### DIFF
--- a/examples/test-tls-dtors.rs
+++ b/examples/test-tls-dtors.rs
@@ -1,0 +1,35 @@
+#![feature(local_key_cell_methods)]
+
+mustang::can_run_this!();
+
+use std::cell::RefCell;
+use std::thread;
+
+fn main() {
+    TLS.with_borrow_mut(|f| {
+        assert_eq!(f.0, 1);
+        *f = Thing(2);
+    });
+    let t = thread::spawn(move || {
+        TLS.with_borrow_mut(|f| {
+            assert_eq!(f.0, 1);
+            *f = Thing(3);
+        });
+    });
+    t.join().unwrap();
+
+    TLS.with_borrow_mut(|f| {
+        assert_eq!(f.0, 2);
+    });
+    eprintln!("main exiting");
+}
+
+struct Thing(i32);
+
+impl Drop for Thing {
+    fn drop(&mut self) {
+        eprintln!("Thing being dropped!");
+    }
+}
+
+thread_local!(static TLS: RefCell<Thing> = RefCell::new(Thing(1)));

--- a/origin/src/program.rs
+++ b/origin/src/program.rs
@@ -169,6 +169,10 @@ pub fn at_exit(func: Box<dyn FnOnce() + Send>) {
 /// Call all the functions registered with [`at_exit`] or with the
 /// `.fini_array` section, and exit the program.
 pub fn exit(status: c_int) -> ! {
+    // Call functions registered with `at_thread_exit`.
+    #[cfg(target_vendor = "mustang")]
+    crate::threads::call_thread_dtors(crate::current_thread());
+
     // Call all the registered functions, in reverse order. Leave `DTORS`
     // unlocked while making the call so that functions can add more functions
     // to the end of the list.

--- a/origin/src/program.rs
+++ b/origin/src/program.rs
@@ -171,6 +171,7 @@ pub fn at_exit(func: Box<dyn FnOnce() + Send>) {
 pub fn exit(status: c_int) -> ! {
     // Call functions registered with `at_thread_exit`.
     #[cfg(target_vendor = "mustang")]
+    #[cfg(feature = "threads")]
     crate::threads::call_thread_dtors(crate::current_thread());
 
     // Call all the registered functions, in reverse order. Leave `DTORS`

--- a/origin/src/threads.rs
+++ b/origin/src/threads.rs
@@ -274,7 +274,7 @@ pub fn at_thread_exit(func: Box<dyn FnOnce()>) {
 }
 
 /// Call the destructors registered with [`at_thread_exit`].
-fn call_thread_dtors(current: Thread) {
+pub(crate) fn call_thread_dtors(current: Thread) {
     // Run the `dtors`, in reverse order of registration. Note that destructors
     // may register new destructors.
     //


### PR DESCRIPTION
When a program calls `exit`, run the TLS destructors in addition to the
regular program-wide destructors.