### PR TITLE
Work on exec functions

### DIFF
--- a/c-scape/src/env/mod.rs
+++ b/c-scape/src/env/mod.rs
@@ -87,4 +87,4 @@ fn init_from_envp(envp: *mut *mut c_char) {
 }
 
 #[no_mangle]
-static mut environ: *mut *mut c_char = null_mut();
+pub(crate) static mut environ: *mut *mut c_char = null_mut();

--- a/c-scape/src/env/mod.rs
+++ b/c-scape/src/env/mod.rs
@@ -1,0 +1,92 @@
+use core::ptr::null_mut;
+use core::slice;
+#[cfg(target_vendor = "mustang")]
+use libc::c_ulong;
+use libc::{c_char, c_int};
+use rustix::ffi::CStr;
+
+#[no_mangle]
+unsafe extern "C" fn getenv(key: *const c_char) -> *mut c_char {
+    libc!(libc::getenv(key));
+    let key = CStr::from_ptr(key.cast());
+    _getenv(key)
+}
+
+pub unsafe fn _getenv(key: &CStr) -> *mut c_char {
+    let mut ptr = environ;
+    loop {
+        let env = *ptr;
+        if env.is_null() {
+            break;
+        }
+        let mut c = env;
+        while *c != (b'=' as c_char) {
+            c = c.add(1);
+        }
+        if key.to_bytes()
+            == slice::from_raw_parts(env.cast::<u8>(), c.offset_from(env).try_into().unwrap())
+        {
+            return c.add(1);
+        }
+        ptr = ptr.add(1);
+    }
+    null_mut()
+}
+
+#[no_mangle]
+unsafe extern "C" fn setenv(name: *const c_char, value: *const c_char, overwrite: c_int) -> c_int {
+    libc!(libc::setenv(name, value, overwrite));
+    unimplemented!("setenv")
+}
+
+#[no_mangle]
+unsafe extern "C" fn unsetenv(name: *const c_char) -> c_int {
+    libc!(libc::unsetenv(name));
+    unimplemented!("unsetenv")
+}
+
+/// GLIBC passes argc, argv, and envp to functions in .init_array, as a
+/// non-standard extension. Use priority 98 so that we run before any
+/// normal user-defined constructor functions and our own functions which
+/// depend on `getenv` working.
+#[cfg(target_env = "gnu")]
+#[link_section = ".init_array.00098"]
+#[used]
+static INIT_ARRAY: unsafe extern "C" fn(c_int, *mut *mut c_char, *mut *mut c_char) = {
+    unsafe extern "C" fn function(_argc: c_int, _argv: *mut *mut c_char, envp: *mut *mut c_char) {
+        init_from_envp(envp);
+    }
+    function
+};
+
+/// For musl etc., assume that `__environ` is available and points to the
+/// original environment from the kernel, so we can find the auxv array in
+/// memory after it. Use priority 98 so that we run before any normal
+/// user-defined constructor functions and our own functions which
+/// depend on `getenv` working.
+///
+/// <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---environ.html>
+#[cfg(not(target_env = "gnu"))]
+#[cfg(not(target_os = "wasi"))]
+#[link_section = ".init_array.00098"]
+#[used]
+static INIT_ARRAY: unsafe extern "C" fn() = {
+    unsafe extern "C" fn function() {
+        extern "C" {
+            static __environ: *mut *mut c_char;
+        }
+
+        init_from_envp(__environ)
+    }
+    function
+};
+
+#[cfg(not(target_os = "wasi"))]
+fn init_from_envp(envp: *mut *mut c_char) {
+    unsafe {
+        environ = envp;
+    }
+}
+
+#[no_mangle]
+static mut environ: *mut *mut c_char = null_mut();

--- a/c-scape/src/env/mod.rs
+++ b/c-scape/src/env/mod.rs
@@ -1,7 +1,5 @@
 use core::ptr::null_mut;
 use core::slice;
-#[cfg(target_vendor = "mustang")]
-use libc::c_ulong;
 use libc::{c_char, c_int};
 use rustix::ffi::CStr;
 
@@ -12,7 +10,7 @@ unsafe extern "C" fn getenv(key: *const c_char) -> *mut c_char {
     _getenv(key)
 }
 
-pub unsafe fn _getenv(key: &CStr) -> *mut c_char {
+pub(crate) unsafe fn _getenv(key: &CStr) -> *mut c_char {
     let mut ptr = environ;
     loop {
         let env = *ptr;

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -62,6 +62,9 @@ use rustix::ffi::CStr;
 // ctype
 mod ctype;
 
+// env
+mod env;
+
 // fs
 mod fs;
 
@@ -648,94 +651,6 @@ unsafe extern "C" fn __sigsetjmp() {
     //libc!(libc::__sigsetjmp());
     unimplemented!("__sigsetjmp")
 }
-
-// Environment variables
-
-#[no_mangle]
-unsafe extern "C" fn getenv(key: *const c_char) -> *mut c_char {
-    libc!(libc::getenv(key));
-    let key = CStr::from_ptr(key.cast());
-    _getenv(key)
-}
-
-unsafe fn _getenv(key: &CStr) -> *mut c_char {
-    let mut ptr = environ;
-    loop {
-        let env = *ptr;
-        if env.is_null() {
-            break;
-        }
-        let mut c = env;
-        while *c != (b'=' as c_char) {
-            c = c.add(1);
-        }
-        if key.to_bytes()
-            == slice::from_raw_parts(env.cast::<u8>(), c.offset_from(env).try_into().unwrap())
-        {
-            return c.add(1);
-        }
-        ptr = ptr.add(1);
-    }
-    null_mut()
-}
-
-#[no_mangle]
-unsafe extern "C" fn setenv(name: *const c_char, value: *const c_char, overwrite: c_int) -> c_int {
-    libc!(libc::setenv(name, value, overwrite));
-    unimplemented!("setenv")
-}
-
-#[no_mangle]
-unsafe extern "C" fn unsetenv(name: *const c_char) -> c_int {
-    libc!(libc::unsetenv(name));
-    unimplemented!("unsetenv")
-}
-
-/// GLIBC passes argc, argv, and envp to functions in .init_array, as a
-/// non-standard extension. Use priority 98 so that we run before any
-/// normal user-defined constructor functions and our own functions which
-/// depend on `getenv` working.
-#[cfg(target_env = "gnu")]
-#[link_section = ".init_array.00098"]
-#[used]
-static INIT_ARRAY: unsafe extern "C" fn(c_int, *mut *mut c_char, *mut *mut c_char) = {
-    unsafe extern "C" fn function(_argc: c_int, _argv: *mut *mut c_char, envp: *mut *mut c_char) {
-        init_from_envp(envp);
-    }
-    function
-};
-
-/// For musl etc., assume that `__environ` is available and points to the
-/// original environment from the kernel, so we can find the auxv array in
-/// memory after it. Use priority 98 so that we run before any normal
-/// user-defined constructor functions and our own functions which
-/// depend on `getenv` working.
-///
-/// <https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/baselib---environ.html>
-#[cfg(not(target_env = "gnu"))]
-#[cfg(not(target_os = "wasi"))]
-#[link_section = ".init_array.00098"]
-#[used]
-static INIT_ARRAY: unsafe extern "C" fn() = {
-    unsafe extern "C" fn function() {
-        extern "C" {
-            static __environ: *mut *mut c_char;
-        }
-
-        init_from_envp(__environ)
-    }
-    function
-};
-
-#[cfg(not(target_os = "wasi"))]
-fn init_from_envp(envp: *mut *mut c_char) {
-    unsafe {
-        environ = envp;
-    }
-}
-
-#[no_mangle]
-static mut environ: *mut *mut c_char = null_mut();
 
 // exit
 

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -58,7 +58,6 @@ use error_str::error_str;
 use libc::c_ulong;
 use libc::{c_char, c_int, c_long};
 use rustix::ffi::CStr;
-use rustix::fs::{AtFlags, Mode, OFlags};
 
 // ctype
 mod ctype;
@@ -604,92 +603,6 @@ unsafe extern "C" fn posix_spawn_file_actions_init(_ptr: *const c_void) -> c_int
 }
 
 // exec
-
-#[cfg(any(target_os = "android", target_os = "linux"))]
-#[no_mangle]
-unsafe extern "C" fn execvp(file: *const c_char, args: *const *const c_char) -> c_int {
-    libc!(libc::execvp(file, args));
-
-    let cwd = rustix::fs::cwd();
-
-    let file = CStr::from_ptr(file);
-    if file.to_bytes().contains(&b'/') {
-        let err = rustix::runtime::execve(file, args.cast(), environ.cast());
-        set_errno(Errno(err.raw_os_error()));
-        return -1;
-    }
-
-    let path = _getenv(rustix::cstr!("PATH"));
-    let path = if path.is_null() {
-        rustix::cstr!("/bin:/usr/bin")
-    } else {
-        CStr::from_ptr(path)
-    };
-
-    let mut access_error = false;
-    for dir in path.to_bytes().split(|byte| *byte == b':') {
-        // Open the directory and use `execveat` to avoid needing to
-        // dynamically allocate a combined path string ourselves.
-        let result = rustix::fs::openat(
-            cwd,
-            dir,
-            OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC | OFlags::NOCTTY,
-            Mode::empty(),
-        )
-        .and_then::<(), _>(|dirfd| {
-            let mut error = rustix::runtime::execveat(
-                &dirfd,
-                file,
-                args.cast(),
-                environ.cast(),
-                AtFlags::empty(),
-            );
-
-            // If `execveat` is unsupported, emulate it with `execve`, without
-            // allocating. This trusts /proc/self/fd.
-            #[cfg(any(target_os = "android", target_os = "linux"))]
-            if let rustix::io::Errno::NOSYS = error {
-                let fd = rustix::fs::openat(
-                    &dirfd,
-                    file,
-                    OFlags::PATH | OFlags::CLOEXEC | OFlags::NOCTTY,
-                    Mode::empty(),
-                )?;
-                const PREFIX: &[u8] = b"/proc/self/fd/";
-                const PREFIX_LEN: usize = PREFIX.len();
-                let mut buf = [0_u8; PREFIX_LEN + 20 + 1];
-                buf[..PREFIX_LEN].copy_from_slice(PREFIX);
-                let fd_dec = rustix::path::DecInt::from_fd(&fd);
-                let fd_bytes = fd_dec.as_c_str().to_bytes_with_nul();
-                buf[PREFIX_LEN..PREFIX_LEN + fd_bytes.len()].copy_from_slice(fd_bytes);
-                error = rustix::runtime::execve(
-                    CStr::from_bytes_with_nul_unchecked(&buf),
-                    args.cast(),
-                    environ.cast(),
-                );
-            }
-
-            Err(error)
-        });
-
-        match result {
-            Ok(()) => (),
-            Err(rustix::io::Errno::ACCESS) => access_error = true,
-            Err(rustix::io::Errno::NOENT) | Err(rustix::io::Errno::NOTDIR) => {}
-            Err(err) => {
-                set_errno(Errno(err.raw_os_error()));
-                return -1;
-            }
-        }
-    }
-
-    set_errno(Errno(if access_error {
-        libc::EACCES
-    } else {
-        libc::ENOENT
-    }));
-    -1
-}
 
 #[cfg(not(target_os = "wasi"))]
 #[no_mangle]

--- a/c-scape/src/process/exec.rs
+++ b/c-scape/src/process/exec.rs
@@ -4,11 +4,10 @@ use rustix::fs::{AtFlags, Mode, OFlags};
 use alloc::vec::Vec;
 use core::ffi::CStr;
 
-use crate::{set_errno, Errno};
 use crate::env::environ;
+use crate::{set_errno, Errno};
 
 use libc::{c_char, c_int};
-
 
 #[no_mangle]
 unsafe extern "C" fn execl(path: *const c_char, arg: *const c_char, mut argv: ...) -> c_int {

--- a/c-scape/src/process/exec.rs
+++ b/c-scape/src/process/exec.rs
@@ -26,7 +26,7 @@ unsafe extern "C" fn execl(path: *const c_char, arg: *const c_char, mut argv: ..
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn execle(path: *const c_char, arg: *const c_char, mut argv: ...) -> c_int {
+unsafe extern "C" fn execle(path: *const c_char, arg: *const c_char, mut argv: ...) -> c_int {
     let mut vec = Vec::new();
     vec.push(arg);
 

--- a/c-scape/src/process/exec.rs
+++ b/c-scape/src/process/exec.rs
@@ -1,0 +1,190 @@
+use rustix::fd::BorrowedFd;
+use rustix::fs::{AtFlags, Mode, OFlags};
+
+use alloc::vec::Vec;
+use core::ffi::CStr;
+
+use crate::{Errno, set_errno};
+
+use libc::{c_char, c_int};
+
+extern "C" {
+    static mut environ: *mut *mut c_char;
+}
+
+#[no_mangle]
+unsafe extern "C" fn execl(
+    path: *const c_char, 
+    arg: *const c_char,
+    mut argv: ...
+) -> c_int {
+    let mut vec = Vec::new();
+    vec.push(arg);
+
+    loop {
+        let ptr = argv.arg::<*const c_char>();
+        vec.push(ptr);
+        if ptr.is_null() {
+            break;
+        }
+    }
+    
+    execv(path, vec.as_ptr())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn execle(
+    path: *const c_char, 
+    arg: *const c_char,
+    mut argv: ...
+) -> c_int {
+    let mut vec = Vec::new();
+    vec.push(arg);
+
+    let envp = loop {
+        let ptr = argv.arg::<*const c_char>();
+        vec.push(ptr);
+        if ptr.is_null() {
+            break argv.arg::<*const *const c_char>();
+        }
+    };
+
+    execve(path, vec.as_ptr(), envp)
+}
+
+#[no_mangle]
+unsafe extern "C" fn execlp(
+    file: *const c_char, 
+    arg: *const c_char,
+    mut argv: ...
+) -> c_int {
+    let mut vec = Vec::new();
+    vec.push(arg);
+
+    loop {
+        let ptr = argv.arg::<*const c_char>();
+        vec.push(ptr);
+        if ptr.is_null() {
+            break;
+        }
+    }
+    
+    execvp(file, vec.as_ptr())
+}
+
+#[no_mangle]
+unsafe extern "C" fn execv(
+    prog: *const c_char, 
+    argv: *const *const c_char
+) -> c_int {
+    execve(prog, argv, environ as *const _)
+}
+
+#[no_mangle]
+unsafe extern "C" fn execve(
+    prog: *const c_char, 
+    argv: *const *const c_char, 
+    envp: *const *const c_char
+) -> c_int {
+    let err = rustix::runtime::execve(CStr::from_ptr(prog), argv as *const *const _, envp as *const *const _);
+
+    set_errno(Errno(err.raw_os_error()));
+    -1
+}
+
+#[no_mangle]
+unsafe extern "C" fn execvp(file: *const c_char, argv: *const *const c_char) -> c_int {
+    let cwd = rustix::fs::cwd();
+
+    let file = CStr::from_ptr(file);
+    if file.to_bytes().contains(&b'/') {
+        let err = rustix::runtime::execve(file, argv.cast(), environ.cast());
+        set_errno(Errno(err.raw_os_error()));
+        return -1;
+    }
+
+    let path = _getenv(rustix::cstr!("PATH"));
+    let path = if path.is_null() {
+        rustix::cstr!("/bin:/usr/bin")
+    } else {
+        CStr::from_ptr(path)
+    };
+
+    let mut access_error = false;
+    for dir in path.to_bytes().split(|byte| *byte == b':') {
+        // Open the directory and use `execveat` to avoid needing to
+        // dynamically allocate a combined path string ourselves.
+        let result = rustix::fs::openat(
+            cwd,
+            dir,
+            OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC | OFlags::NOCTTY,
+            Mode::empty(),
+        )
+        .and_then::<(), _>(|dirfd| {
+            let mut error = rustix::runtime::execveat(
+                &dirfd,
+                file,
+                argv.cast(),
+                environ.cast(),
+                AtFlags::empty(),
+            );
+
+            // If `execveat` is unsupported, emulate it with `execve`, without
+            // allocating. This trusts /proc/self/fd.
+            #[cfg(any(target_os = "android", target_os = "linux"))]
+            if let rustix::io::Errno::NOSYS = error {
+                let fd = rustix::fs::openat(
+                    &dirfd,
+                    file,
+                    OFlags::PATH | OFlags::CLOEXEC | OFlags::NOCTTY,
+                    Mode::empty(),
+                )?;
+                const PREFIX: &[u8] = b"/proc/self/fd/";
+                const PREFIX_LEN: usize = PREFIX.len();
+                let mut buf = [0_u8; PREFIX_LEN + 20 + 1];
+                buf[..PREFIX_LEN].copy_from_slice(PREFIX);
+                let fd_dec = rustix::path::DecInt::from_fd(&fd);
+                let fd_bytes = fd_dec.as_c_str().to_bytes_with_nul();
+                buf[PREFIX_LEN..PREFIX_LEN + fd_bytes.len()].copy_from_slice(fd_bytes);
+                error = rustix::runtime::execve(
+                    CStr::from_bytes_with_nul_unchecked(&buf),
+                    argv.cast(),
+                    environ.cast(),
+                );
+            }
+
+            Err(error)
+        });
+
+        match result {
+            Ok(()) => (),
+            Err(rustix::io::Errno::ACCESS) => access_error = true,
+            Err(rustix::io::Errno::NOENT) | Err(rustix::io::Errno::NOTDIR) => {}
+            Err(err) => {
+                set_errno(Errno(err.raw_os_error()));
+                return -1;
+            }
+        }
+    }
+
+    set_errno(Errno(if access_error {
+        libc::EACCES
+    } else {
+        libc::ENOENT
+    }));
+    -1
+}
+
+#[no_mangle]
+unsafe extern "C" fn fexecve(
+    fd: c_int, 
+    argv: *const *const c_char, 
+    envp: *const *const c_char
+) -> c_int {
+    let err = rustix::runtime::execveat(BorrowedFd::borrow_raw(fd), rustix::cstr!("") ,argv as *const *const _, envp as *const *const _, AtFlags::EMPTY_PATH);
+
+    // TODO: old kernel support
+
+    set_errno(Errno(err.raw_os_error()));
+    -1
+}

--- a/c-scape/src/process/mod.rs
+++ b/c-scape/src/process/mod.rs
@@ -1,6 +1,7 @@
 mod chdir;
 mod egid;
 mod euid;
+mod exec;
 mod getcwd;
 mod gid;
 mod groups;


### PR DESCRIPTION
The main thing I'm not sure about here is how we want to handle calling Rust functions from one module from another, such as the `environ` or `_getenv`. I think the move here is to reexport everything as `pub (crate)` or have some sort of crate only `imp` module that everything goes into, but I'm open to ideas.