### PR TITLE
Update tests/net-ip.rs to the latest upstream.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     env:
-      QEMU_BUILD_VERSION: 7.0.0
+      QEMU_BUILD_VERSION: 7.1.0
     strategy:
       matrix:
         build: [ubuntu, ubuntu-18.04, i686-linux, aarch64-linux, riscv64-linux]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,17 +30,17 @@ jobs:
         include:
           - build: ubuntu
             os: ubuntu-latest
-            rust: nightly-2022-08-07
+            rust: nightly
             host_target: x86_64-unknown-linux-gnu
             mustang_target: x86_64-mustang-linux-gnu
           - build: ubuntu-18.04
             os: ubuntu-18.04
-            rust: nightly-2022-08-07
+            rust: nightly
             host_target: x86_64-unknown-linux-gnu
             mustang_target: x86_64-mustang-linux-gnu
           - build: i686-linux
             os: ubuntu-latest
-            rust: nightly-2022-08-07
+            rust: nightly
             target: i686-unknown-linux-gnu
             gcc_package: gcc-i686-linux-gnu
             gcc: i686-linux-gnu-gcc
@@ -49,7 +49,7 @@ jobs:
             mustang_target: i686-mustang-linux-gnu
           - build: aarch64-linux
             os: ubuntu-latest
-            rust: nightly-2022-08-07
+            rust: nightly
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
@@ -59,7 +59,7 @@ jobs:
             mustang_target: aarch64-mustang-linux-gnu
           - build: riscv64-linux
             os: ubuntu-latest
-            rust: nightly-2022-08-07
+            rust: nightly
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
@@ -140,28 +140,28 @@ jobs:
 
     - name: Install rust-src
       run: |
-        rustup component add rust-src --toolchain nightly-2022-08-07-x86_64-unknown-linux-gnu
+        rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
 
     - name: cargo check non-mustang
       run: |
         # Check that the code compiles on non-mustang targets.
-        cargo +nightly-2022-08-07 check --all --target=${{ matrix.host_target }}
+        cargo +nightly check --all --target=${{ matrix.host_target }}
 
     - name: cargo test
       run: |
-        cargo +nightly-2022-08-07 test --verbose -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json -- ${{ matrix.test_args }} -- --nocapture
+        cargo +nightly test --verbose -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json -- ${{ matrix.test_args }} -- --nocapture
       env:
         RUST_BACKTRACE: 1
 
     - name: cargo test --release
       run: |
-        cargo +nightly-2022-08-07 test --verbose --release -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json  -- ${{ matrix.test_args }}
+        cargo +nightly test --verbose --release -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json  -- ${{ matrix.test_args }}
       env:
         RUST_BACKTRACE: 1
 
     - name: test mustang_use_libc
       run: |
-        RUSTFLAGS=--cfg=mustang_use_libc cargo +nightly-2022-08-07 check --workspace -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json
+        RUSTFLAGS=--cfg=mustang_use_libc cargo +nightly check --workspace -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json
       env:
         RUST_BACKTRACE: 1
 
@@ -182,13 +182,13 @@ jobs:
     - name: test libc-replacement in non-mustang mode
       working-directory: test-crates/libc-replacement
       run: |
-        cargo +nightly-2022-08-07 run --target=${{ matrix.host_target }}
+        cargo +nightly run --target=${{ matrix.host_target }}
       env:
         RUST_BACKTRACE: 1
 
     - name: test origin-as-just-a-library in non-mustang mode
       working-directory: test-crates/origin-as-just-a-library
       run: |
-        cargo +nightly-2022-08-07 run --target=${{ matrix.host_target }}
+        cargo +nightly run --target=${{ matrix.host_target }}
       env:
         RUST_BACKTRACE: 1

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -40,7 +40,7 @@ fn test_example(name: &str, features: &str, stdout: &str, stderr: &str) {
     let env = "gnu";
 
     let mut command = Command::new("cargo");
-    command.arg("+nightly-2022-08-07").arg("run").arg("--quiet");
+    command.arg("+nightly").arg("run").arg("--quiet");
     if !features.is_empty() {
         command
             .arg("--no-default-features")


### PR DESCRIPTION
This syncs up mustang with the change "Fix `Ipv6Addr::is_global` to check for global reachability rather than global scope".