### PR TITLE
c-scape: add pthread_setname_np (#139)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,17 +30,17 @@ jobs:
         include:
           - build: ubuntu
             os: ubuntu-latest
-            rust: nightly-2022-08-07
+            rust: nightly-2022-09-19
             host_target: x86_64-unknown-linux-gnu
             mustang_target: x86_64-mustang-linux-gnu
           - build: ubuntu-18.04
             os: ubuntu-18.04
-            rust: nightly-2022-08-07
+            rust: nightly-2022-09-19
             host_target: x86_64-unknown-linux-gnu
             mustang_target: x86_64-mustang-linux-gnu
           - build: i686-linux
             os: ubuntu-latest
-            rust: nightly-2022-08-07
+            rust: nightly-2022-09-19
             target: i686-unknown-linux-gnu
             gcc_package: gcc-i686-linux-gnu
             gcc: i686-linux-gnu-gcc
@@ -49,7 +49,7 @@ jobs:
             mustang_target: i686-mustang-linux-gnu
           - build: aarch64-linux
             os: ubuntu-latest
-            rust: nightly-2022-08-07
+            rust: nightly-2022-09-19
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
@@ -59,7 +59,7 @@ jobs:
             mustang_target: aarch64-mustang-linux-gnu
           - build: riscv64-linux
             os: ubuntu-latest
-            rust: nightly-2022-08-07
+            rust: nightly-2022-09-19
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
@@ -140,28 +140,28 @@ jobs:
 
     - name: Install rust-src
       run: |
-        rustup component add rust-src --toolchain nightly-2022-08-07-x86_64-unknown-linux-gnu
+        rustup component add rust-src --toolchain nightly-2022-09-19-x86_64-unknown-linux-gnu
 
     - name: cargo check non-mustang
       run: |
         # Check that the code compiles on non-mustang targets.
-        cargo +nightly-2022-08-07 check --all --target=${{ matrix.host_target }}
+        cargo +nightly-2022-09-19 check --all --target=${{ matrix.host_target }}
 
     - name: cargo test
       run: |
-        cargo +nightly-2022-08-07 test --verbose -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json -- ${{ matrix.test_args }} -- --nocapture
+        cargo +nightly-2022-09-19 test --verbose -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json -- ${{ matrix.test_args }} -- --nocapture
       env:
         RUST_BACKTRACE: 1
 
     - name: cargo test --release
       run: |
-        cargo +nightly-2022-08-07 test --verbose --release -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json  -- ${{ matrix.test_args }}
+        cargo +nightly-2022-09-19 test --verbose --release -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json  -- ${{ matrix.test_args }}
       env:
         RUST_BACKTRACE: 1
 
     - name: test mustang_use_libc
       run: |
-        RUSTFLAGS=--cfg=mustang_use_libc cargo +nightly-2022-08-07 check --workspace -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json
+        RUSTFLAGS=--cfg=mustang_use_libc cargo +nightly-2022-09-19 check --workspace -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json
       env:
         RUST_BACKTRACE: 1
 
@@ -182,13 +182,13 @@ jobs:
     - name: test libc-replacement in non-mustang mode
       working-directory: test-crates/libc-replacement
       run: |
-        cargo +nightly-2022-08-07 run --target=${{ matrix.host_target }}
+        cargo +nightly-2022-09-19 run --target=${{ matrix.host_target }}
       env:
         RUST_BACKTRACE: 1
 
     - name: test origin-as-just-a-library in non-mustang mode
       working-directory: test-crates/origin-as-just-a-library
       run: |
-        cargo +nightly-2022-08-07 run --target=${{ matrix.host_target }}
+        cargo +nightly-2022-09-19 run --target=${{ matrix.host_target }}
       env:
         RUST_BACKTRACE: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,17 +30,17 @@ jobs:
         include:
           - build: ubuntu
             os: ubuntu-latest
-            rust: nightly-2022-09-19
+            rust: nightly-2022-09-27
             host_target: x86_64-unknown-linux-gnu
             mustang_target: x86_64-mustang-linux-gnu
           - build: ubuntu-18.04
             os: ubuntu-18.04
-            rust: nightly-2022-09-19
+            rust: nightly-2022-09-27
             host_target: x86_64-unknown-linux-gnu
             mustang_target: x86_64-mustang-linux-gnu
           - build: i686-linux
             os: ubuntu-latest
-            rust: nightly-2022-09-19
+            rust: nightly-2022-09-27
             target: i686-unknown-linux-gnu
             gcc_package: gcc-i686-linux-gnu
             gcc: i686-linux-gnu-gcc
@@ -49,7 +49,7 @@ jobs:
             mustang_target: i686-mustang-linux-gnu
           - build: aarch64-linux
             os: ubuntu-latest
-            rust: nightly-2022-09-19
+            rust: nightly-2022-09-27
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
@@ -59,7 +59,7 @@ jobs:
             mustang_target: aarch64-mustang-linux-gnu
           - build: riscv64-linux
             os: ubuntu-latest
-            rust: nightly-2022-09-19
+            rust: nightly-2022-09-27
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
@@ -140,28 +140,28 @@ jobs:
 
     - name: Install rust-src
       run: |
-        rustup component add rust-src --toolchain nightly-2022-09-19-x86_64-unknown-linux-gnu
+        rustup component add rust-src --toolchain nightly-2022-09-27-x86_64-unknown-linux-gnu
 
     - name: cargo check non-mustang
       run: |
         # Check that the code compiles on non-mustang targets.
-        cargo +nightly-2022-09-19 check --all --target=${{ matrix.host_target }}
+        cargo +nightly-2022-09-27 check --all --target=${{ matrix.host_target }}
 
     - name: cargo test
       run: |
-        cargo +nightly-2022-09-19 test --verbose -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json -- ${{ matrix.test_args }} -- --nocapture
+        cargo +nightly-2022-09-27 test --verbose -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json -- ${{ matrix.test_args }} -- --nocapture
       env:
         RUST_BACKTRACE: 1
 
     - name: cargo test --release
       run: |
-        cargo +nightly-2022-09-19 test --verbose --release -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json  -- ${{ matrix.test_args }}
+        cargo +nightly-2022-09-27 test --verbose --release -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json  -- ${{ matrix.test_args }}
       env:
         RUST_BACKTRACE: 1
 
     - name: test mustang_use_libc
       run: |
-        RUSTFLAGS=--cfg=mustang_use_libc cargo +nightly-2022-09-19 check --workspace -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json
+        RUSTFLAGS=--cfg=mustang_use_libc cargo +nightly-2022-09-27 check --workspace -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json
       env:
         RUST_BACKTRACE: 1
 
@@ -182,13 +182,13 @@ jobs:
     - name: test libc-replacement in non-mustang mode
       working-directory: test-crates/libc-replacement
       run: |
-        cargo +nightly-2022-09-19 run --target=${{ matrix.host_target }}
+        cargo +nightly-2022-09-27 run --target=${{ matrix.host_target }}
       env:
         RUST_BACKTRACE: 1
 
     - name: test origin-as-just-a-library in non-mustang mode
       working-directory: test-crates/origin-as-just-a-library
       run: |
-        cargo +nightly-2022-09-19 run --target=${{ matrix.host_target }}
+        cargo +nightly-2022-09-27 run --target=${{ matrix.host_target }}
       env:
         RUST_BACKTRACE: 1

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -335,7 +335,7 @@ unsafe extern "C" fn sched_getaffinity(
 
 // In Linux, `prctl`'s arguments are described as `unsigned long`, however we
 // use pointer types in order to preserve provenance.
-#[cfg(target_os = "android")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 #[no_mangle]
 unsafe extern "C" fn prctl(
     option: c_int,

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -335,7 +335,7 @@ unsafe extern "C" fn sched_getaffinity(
 
 // In Linux, `prctl`'s arguments are described as `unsigned long`, however we
 // use pointer types in order to preserve provenance.
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(target_os = "android")]
 #[no_mangle]
 unsafe extern "C" fn prctl(
     option: c_int,
@@ -355,6 +355,21 @@ unsafe extern "C" fn prctl(
             }
         }
         _ => unimplemented!("unrecognized prctl op {}", option),
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[no_mangle]
+unsafe extern "C" fn pthread_setname_np(
+    thread: libc::pthread_t,
+    name: *const libc::c_char
+) -> c_int {
+    libc!(libc::pthread_setname_np(thread, name));
+    match convert_res(rustix::runtime::set_thread_name(CStr::from_ptr(
+        name as *const _,
+    ))) {
+        Some(()) => 0,
+        None => -1,
     }
 }
 

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -362,7 +362,7 @@ unsafe extern "C" fn prctl(
 #[no_mangle]
 unsafe extern "C" fn pthread_setname_np(
     thread: libc::pthread_t,
-    name: *const libc::c_char
+    name: *const libc::c_char,
 ) -> c_int {
     libc!(libc::pthread_setname_np(thread, name));
     match convert_res(rustix::runtime::set_thread_name(CStr::from_ptr(

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -40,7 +40,7 @@ fn test_example(name: &str, features: &str, stdout: &str, stderr: &str) {
     let env = "gnu";
 
     let mut command = Command::new("cargo");
-    command.arg("+nightly-2022-08-07").arg("run").arg("--quiet");
+    command.arg("+nightly-2022-09-27").arg("run").arg("--quiet");
     if !features.is_empty() {
         command
             .arg("--no-default-features")


### PR DESCRIPTION
As mentioned in the issue #139, any code using threads fails to link. Since this commit, rust links against a pthread_setname_np on linux. Android is unaffected. https://github.com/rust-lang/rust/commit/013986be1bcfbfd9cedddf22dfd9584ccdb7ee6e