### PR TITLE
Don't use the memchr crate to implement `memchr`.

### DIFF
--- a/c-gull/README.md
+++ b/c-gull/README.md
@@ -17,7 +17,7 @@ c-gull is a libc implementation. It is an implementation of the ABI described
 by the [libc] crate.
 
 It is implemented in terms of crates written in Rust, such as [c-scape],
-[rustix], [origin], [sync-resolve], [libm], [realpath-ext], [memchr], [tz-rs],
+[rustix], [origin], [sync-resolve], [libm], [realpath-ext], [tz-rs],
 [printf-compat], and [rand].
 
 Currently it only supports `*-*-linux-gnu` ABIs, though other ABIs could be
@@ -61,7 +61,6 @@ See the [libc-replacement example] for more details.
 [libm]: https://crates.io/crates/libm
 [libc]: https://crates.io/crates/libc
 [realpath-ext]: https://crates.io/crates/realpath-ext
-[memchr]: https://crates.io/crates/memchr
 [mustang]: https://crates.io/crates/mustang
 [tz-rs]: https://crates.io/crates/tz-rs
 [printf-compat]: https://crates.io/crates/printf-compat

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -15,7 +15,6 @@ libm = "0.2.1"
 rustix = { version = "0.35.6", default-features = false, features = ["fs", "itoa", "net", "param", "process", "rand", "termios", "thread", "time"] }
 memoffset = "0.6"
 realpath-ext = { version = "0.1.0", default-features = false }
-memchr = { version = "2.4.1", default-features = false }
 sync-resolve = { version = "0.3.0", optional = true }
 origin = { path = "../origin", default-features = false, version = "^0.5.0" }
 log = { version = "0.4.14", default-features = false }

--- a/c-scape/src/mem/bstring.rs
+++ b/c-scape/src/mem/bstring.rs
@@ -1,5 +1,4 @@
 use core::ptr::null_mut;
-use core::slice;
 use libc::{c_int, c_void};
 
 // Obsolescent
@@ -23,7 +22,7 @@ unsafe extern "C" fn memchr(s: *const c_void, c: c_int, len: usize) -> *mut c_vo
     // [memchr crate](https://crates.io/crates/memchr)
     for i in 0..len {
         if *s.cast::<u8>().add(i) == c as u8 {
-            return s.cast::<u8>().add(i).cast::<c_void>();
+            return s.cast::<u8>().add(i).cast::<c_void>() as *mut c_void;
         }
     }
     null_mut()
@@ -38,7 +37,7 @@ unsafe extern "C" fn memrchr(s: *const c_void, c: c_int, len: usize) -> *mut c_v
     // requirements that we can't meet here.
     for i in 0..len {
         if *s.cast::<u8>().add(len - i - 1) == c as u8 {
-            return s.cast::<u8>().add(len - i - 1).cast::<c_void>();
+            return s.cast::<u8>().add(len - i - 1).cast::<c_void>() as *mut c_void;
         }
     }
     null_mut()

--- a/c-scape/src/mem/bstring.rs
+++ b/c-scape/src/mem/bstring.rs
@@ -15,11 +15,18 @@ unsafe extern "C" fn bcmp(a: *const c_void, b: *const c_void, len: usize) -> c_i
 unsafe extern "C" fn memchr(s: *const c_void, c: c_int, len: usize) -> *mut c_void {
     libc!(libc::memchr(s, c, len));
 
-    let slice: &[u8] = slice::from_raw_parts(s.cast(), len);
-    match memchr::memchr(c as u8, slice) {
-        None => null_mut(),
-        Some(i) => s.cast::<u8>().add(i) as *mut c_void,
+    // It's tempting to use the [memchr crate] to optimize this. However its
+    // API requires a Rust slice, which requires that all `len` bytes of the
+    // buffer be accessible, while the C `memchr` API guarantees that it stops
+    // accessing memory at the first byte that matches.
+    //
+    // [memchr crate](https://crates.io/crates/memchr)
+    for i in 0..len {
+        if *s.cast::<u8>().add(i) == c as u8 {
+            return s.cast::<u8>().add(i).cast::<c_void>();
+        }
     }
+    null_mut()
 }
 
 // Extension: GNU
@@ -27,11 +34,14 @@ unsafe extern "C" fn memchr(s: *const c_void, c: c_int, len: usize) -> *mut c_vo
 unsafe extern "C" fn memrchr(s: *const c_void, c: c_int, len: usize) -> *mut c_void {
     libc!(libc::memrchr(s, c, len));
 
-    let slice: &[u8] = slice::from_raw_parts(s.cast(), len);
-    match memchr::memrchr(c as u8, slice) {
-        None => null_mut(),
-        Some(i) => s.cast::<u8>().add(i) as *mut c_void,
+    // As above, it's tempting to use the memchr crate, but the C API here has
+    // requirements that we can't meet here.
+    for i in 0..len {
+        if *s.cast::<u8>().add(len - i - 1) == c as u8 {
+            return s.cast::<u8>().add(len - i - 1).cast::<c_void>();
+        }
     }
+    null_mut()
 }
 
 #[no_mangle]


### PR DESCRIPTION
Fixes #141.