### PR TITLE
Rand48 fixes + libc bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ c-scape = { path = "c-scape", version = "^0.6.1" }
 c-gull = { path = "c-gull", version = "^0.6.1" }
 similar-asserts = "1.1.0"
 rand = "0.8.4"
-libc = "0.2.126"
+libc = "0.2.138"
 
 # Test that the ctor crate works under mustang.
 ctor = "0.1.21"

--- a/c-gull/Cargo.toml
+++ b/c-gull/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 rustix = { version = "0.36.1", default-features = false, features = ["fs", "itoa", "net", "param", "process", "rand", "termios", "thread", "time"] }
 # We use the libc crate for C ABI types and constants, but we don't depend on
 # the actual platform libc.
-libc = { version = "0.2.126", default-features = false }
+libc = { version = "0.2.138", default-features = false }
 errno = { version = "0.2.8", default-features = false }
 c-scape = { path = "../c-scape", version = "0.6.1" }
 tz-rs = "0.6.11"
@@ -22,7 +22,7 @@ printf-compat = "0.1.1"
 log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
-libc = "0.2.126"
+libc = "0.2.138"
 
 [features]
 default = ["threads"]

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -20,7 +20,7 @@ origin = { path = "../origin", default-features = false, version = "^0.6.1" }
 log = { version = "0.4.14", default-features = false }
 # We use the libc crate for C ABI types and constants, but we don't depend on
 # the actual platform libc.
-libc = { version = "0.2.126", default-features = false }
+libc = { version = "0.2.138", default-features = false }
 errno = { version = "0.2.8", default-features = false }
 
 [build-dependencies]
@@ -29,7 +29,7 @@ errno = { version = "0.2.8", default-features = false }
 cc = { version = "1.0.68", optional = true }
 
 [dev-dependencies]
-libc = "0.2.126"
+libc = "0.2.138"
 static_assertions = "1.1.0"
 paste = "1.0.5"
 once_cell = "1.8.0"

--- a/origin/Cargo.toml
+++ b/origin/Cargo.toml
@@ -24,7 +24,7 @@ lock_api = { version = "0.4.7", features = ["nightly"] }
 env_logger = { version = "0.10.0", optional = true }
 
 [target.'cfg(not(target_vendor = "mustang"))'.dependencies]
-libc = { version = "0.2.126", default-features = false }
+libc = { version = "0.2.138", default-features = false }
 
 # Special dependencies used in rustc-dep-of-std mode.
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }

--- a/test-crates/mustang-macro-does-nothing/README.md
+++ b/test-crates/mustang-macro-does-nothing/README.md
@@ -18,7 +18,7 @@ mustang-macro-does-nothing v0.0.0 (mustang/test-crates/mustang-macro-does-nothin
     ├── c-gull v0.5.1 (mustang/c-gull)
     │   ├── c-scape v0.5.1 (mustang/c-scape)
     │   │   ├── errno v0.2.8
-    │   │   │   └── libc v0.2.126
-    │   │   ├── libc v0.2.126
+    │   │   │   └── libc v0.2.138
+    │   │   ├── libc v0.2.138
 ...
 ```


### PR DESCRIPTION
This bumps libc to get the `rand48` definitions into mustang. I've also slightly refactored how `erand48` converts to a float in order to better distribute the bits randomly.