### PR TITLE
Add splice and sendfile

### DIFF
--- a/c-scape/src/fs/mod.rs
+++ b/c-scape/src/fs/mod.rs
@@ -11,6 +11,7 @@ mod readlink;
 mod realpath;
 mod remove;
 mod rename;
+mod sendfile;
 mod stat;
 mod symlink;
 mod sync;

--- a/c-scape/src/fs/sendfile.rs
+++ b/c-scape/src/fs/sendfile.rs
@@ -1,7 +1,7 @@
 use rustix::fd::BorrowedFd;
 
 use errno::{set_errno, Errno};
-use libc::{c_int, size_t, off64_t, off_t};
+use libc::{c_int, off64_t, off_t, size_t};
 
 use crate::convert_res;
 
@@ -11,17 +11,17 @@ unsafe extern "C" fn sendfile(
     out_fd: c_int,
     in_fd: c_int,
     offset: *mut off_t,
-    count: size_t
+    count: size_t,
 ) -> isize {
     libc!(libc::sendfile(out_fd, in_fd, offset, count));
-    
-    Check for overflow into off64_t
+
+    // Check for overflow into off64_t
     if !offset.is_null() {
         if *offset < 0 {
             set_errno(Errno(libc::EINVAL));
             return -1;
         }
-    
+
         // If count is too big then we just fail immediately
         if let Ok(add) = TryInto::<off_t>::try_into(count) {
             // Check if count + offset could overflow and return EINVAL
@@ -51,12 +51,12 @@ unsafe extern "C" fn sendfile64(
     out_fd: c_int,
     in_fd: c_int,
     offset: *mut off64_t,
-    count: size_t
+    count: size_t,
 ) -> isize {
     libc!(libc::sendfile64(out_fd, in_fd, offset, count));
 
     let offset: *mut u64 = checked_cast!(offset);
-    
+
     match convert_res(rustix::fs::sendfile(
         BorrowedFd::borrow_raw(out_fd),
         BorrowedFd::borrow_raw(in_fd),

--- a/c-scape/src/fs/sendfile.rs
+++ b/c-scape/src/fs/sendfile.rs
@@ -1,0 +1,69 @@
+use rustix::fd::BorrowedFd;
+
+use errno::{set_errno, Errno};
+use libc::{c_int, size_t, off64_t, off_t};
+
+use crate::convert_res;
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[no_mangle]
+unsafe extern "C" fn sendfile(
+    out_fd: c_int,
+    in_fd: c_int,
+    offset: *mut off_t,
+    count: size_t
+) -> isize {
+    libc!(libc::sendfile(out_fd, in_fd, offset, count));
+    
+    Check for overflow into off64_t
+    if !offset.is_null() {
+        if *offset < 0 {
+            set_errno(Errno(libc::EINVAL));
+            return -1;
+        }
+    
+        // If count is too big then we just fail immediately
+        if let Ok(add) = TryInto::<off_t>::try_into(count) {
+            // Check if count + offset could overflow and return EINVAL
+            if add.overflowing_add(*offset).1 {
+                set_errno(Errno(libc::EINVAL));
+                return -1;
+            }
+        } else {
+            set_errno(Errno(libc::EINVAL));
+            return -1;
+        }
+    }
+
+    let mut offset_64: off64_t = 0;
+    let res = sendfile64(out_fd, in_fd, &mut offset_64, count);
+
+    if !offset.is_null() {
+        // Safe cast as we checked above
+        *offset = offset_64 as off_t;
+    }
+    return res;
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[no_mangle]
+unsafe extern "C" fn sendfile64(
+    out_fd: c_int,
+    in_fd: c_int,
+    offset: *mut off64_t,
+    count: size_t
+) -> isize {
+    libc!(libc::sendfile64(out_fd, in_fd, offset, count));
+
+    let offset: *mut u64 = checked_cast!(offset);
+    
+    match convert_res(rustix::fs::sendfile(
+        BorrowedFd::borrow_raw(out_fd),
+        BorrowedFd::borrow_raw(in_fd),
+        offset.as_mut(),
+        count.into(),
+    )) {
+        Some(num) => num.try_into().unwrap(),
+        None => -1,
+    }
+}

--- a/c-scape/src/io/mod.rs
+++ b/c-scape/src/io/mod.rs
@@ -6,13 +6,14 @@ mod isatty;
 mod pipe;
 mod poll;
 mod read;
+mod splice;
 mod write;
 
 use rustix::fd::{BorrowedFd, IntoRawFd};
 use rustix::io::EventfdFlags;
 
 use core::convert::TryInto;
-use libc::{c_int, c_long, c_uint, loff_t};
+use libc::{c_int, c_long, c_uint};
 
 use crate::convert_res;
 
@@ -57,27 +58,6 @@ unsafe extern "C" fn ioctl(fd: c_int, request: c_long, mut args: ...) -> c_int {
         }
         _ => panic!("unrecognized ioctl({})", request),
     }
-}
-
-#[cfg(any(target_os = "android", target_os = "linux"))]
-#[no_mangle]
-unsafe extern "C" fn sendfile() {
-    //libc!(libc::sendfile());
-    unimplemented!("sendfile")
-}
-
-#[cfg(any(target_os = "android", target_os = "linux"))]
-#[no_mangle]
-unsafe extern "C" fn splice(
-    fd_in: c_int,
-    off_in: *mut loff_t,
-    fd_out: c_int,
-    off_out: *mut loff_t,
-    len: usize,
-    flags: c_uint,
-) -> isize {
-    libc!(libc::splice(fd_in, off_in, fd_out, off_out, len, flags));
-    unimplemented!("splice");
 }
 
 #[cfg(feature = "net")]

--- a/c-scape/src/io/splice.rs
+++ b/c-scape/src/io/splice.rs
@@ -1,0 +1,34 @@
+use rustix::fd::BorrowedFd;
+use rustix::io::SpliceFlags;
+
+use libc::{c_int, c_uint, loff_t};
+
+use crate::convert_res;
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[no_mangle]
+unsafe extern "C" fn splice(
+    fd_in: c_int,
+    off_in: *mut loff_t,
+    fd_out: c_int,
+    off_out: *mut loff_t,
+    len: usize,
+    flags: c_uint,
+) -> isize {
+    libc!(libc::splice(fd_in, off_in, fd_out, off_out, len, flags));
+
+    let off_in: *mut u64 = checked_cast!(off_in);
+    let off_out: *mut u64 = checked_cast!(off_out);
+    
+    match convert_res(rustix::io::splice(
+        BorrowedFd::borrow_raw(fd_in),
+        off_in.as_mut(),
+        BorrowedFd::borrow_raw(fd_out),
+        off_out.as_mut(),
+        len,
+        SpliceFlags::from_bits(flags as _).unwrap(),
+    )) {
+        Some(num) => num.try_into().unwrap(),
+        None => -1,
+    }
+}

--- a/c-scape/src/io/splice.rs
+++ b/c-scape/src/io/splice.rs
@@ -19,7 +19,7 @@ unsafe extern "C" fn splice(
 
     let off_in: *mut u64 = checked_cast!(off_in);
     let off_out: *mut u64 = checked_cast!(off_out);
-    
+
     match convert_res(rustix::io::splice(
         BorrowedFd::borrow_raw(fd_in),
         off_in.as_mut(),

--- a/tests/kernel_copy.rs
+++ b/tests/kernel_copy.rs
@@ -293,4 +293,3 @@ fn bench_socket_pipe_socket_copy(b: &mut test::Bencher) {
         );
     });
 }
-

--- a/tests/kernel_copy.rs
+++ b/tests/kernel_copy.rs
@@ -6,7 +6,6 @@
 
 mustang::can_run_this!();
 
-/* FIXME(mustang): Needs `sendfile` and `splice`.
 mod sys_common;
 
 use std::fs::OpenOptions;
@@ -294,4 +293,4 @@ fn bench_socket_pipe_socket_copy(b: &mut test::Bencher) {
         );
     });
 }
-*/
+


### PR DESCRIPTION
Adds splice and sendfile, as those got added sometime in when I last looked at this and now.

I'm very unsure of all the unsigned to signed conversions and back here, and I'm not really sure why `rustix` has offsets as unsigned here.

I've uncommented the tests, but strangely enough I don't think that tests actually tests the splice or sendfile path, as those appear locked behind benches. I will add some tests for this.