### PR TITLE
Start making mustang's c-gull dependency optional.

### DIFF
--- a/c-gull/Cargo.toml
+++ b/c-gull/Cargo.toml
@@ -16,7 +16,7 @@ rustix = { version = "0.36.1", default-features = false, features = ["fs", "itoa
 # the actual platform libc.
 libc = { version = "0.2.138", default-features = false }
 errno = { version = "0.2.8", default-features = false }
-c-scape = { path = "../c-scape", version = "0.6.1" }
+c-scape = { path = "../c-scape", version = "0.6.1", features = ["std"] }
 tz-rs = "0.6.11"
 printf-compat = "0.1.1"
 log = { version = "0.4.14", default-features = false }

--- a/mustang/Cargo.toml
+++ b/mustang/Cargo.toml
@@ -33,7 +33,7 @@ features = [
 
 [target.'cfg(target_vendor = "mustang")'.dependencies]
 origin = { path = "../origin", default-features = false, version = "^0.6.1" }
-c-gull = { path = "../c-gull", version = "^0.6.1" }
+c-gull = { path = "../c-gull", version = "^0.6.1", optional = true }
 
 # A general-purpose `global_allocator` implementation.
 dlmalloc = { version = "0.2", features = ["global"], optional = true }
@@ -41,9 +41,10 @@ dlmalloc = { version = "0.2", features = ["global"], optional = true }
 wee_alloc = { version = "0.4", optional = true }
 
 [features]
-default = ["default-alloc", "threads"]
+default = ["default-alloc", "threads", "std"]
 default-alloc = ["dlmalloc"]
 threads = ["origin/threads", "c-gull/threads"]
 env_logger = ["origin/env_logger"]
 log = ["origin/log"]
 max_level_off = ["origin/max_level_off"]
+std = ["c-gull"]

--- a/mustang/src/lib.rs
+++ b/mustang/src/lib.rs
@@ -25,6 +25,7 @@ macro_rules! can_run_this {
     () => {};
 }
 
+#[cfg(feature = "std")]
 #[cfg(target_vendor = "mustang")]
 extern crate c_gull;
 #[cfg(target_vendor = "mustang")]


### PR DESCRIPTION
c-gull is the part of mustang which depends on std, so start making it optional to enable no_std use cases.