### PR TITLE
Move resolve into c-gull (and remove c-scape net feature)

### DIFF
--- a/c-gull/Cargo.toml
+++ b/c-gull/Cargo.toml
@@ -17,7 +17,8 @@ libc = { version = "0.2.138", default-features = false }
 c-scape = { path = "../c-scape", version = "0.6.1", default-features = false }
 errno = { version = "0.2.8", default-features = false, optional = true }
 tz-rs = { version = "0.6.11", optional = true }
-printf-compat = { version = "0.1.1", optional = true}
+printf-compat = { version = "0.1.1", optional = true }
+sync-resolve = { version = "0.3.0", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
 rustix = { version = "0.36.1", default-features = false, optional = true, features = ["fs", "itoa", "net", "param", "process", "rand", "termios", "thread", "time"] }
 
@@ -27,4 +28,4 @@ libc = "0.2.138"
 [features]
 default = ["threads", "std"]
 threads = ["c-scape/threads"]
-std = ["c-scape/default", "rustix", "log", "printf-compat", "tz-rs", "errno"]
+std = ["c-scape/std", "rustix", "log", "printf-compat", "tz-rs", "errno", "sync-resolve"]

--- a/c-gull/src/lib.rs
+++ b/c-gull/src/lib.rs
@@ -20,6 +20,8 @@ mod nss;
 #[cfg(feature = "std")]
 mod printf;
 #[cfg(feature = "std")]
+mod resolve;
+#[cfg(feature = "std")]
 mod strtod;
 #[cfg(feature = "std")]
 mod strtol;

--- a/c-gull/src/resolve.rs
+++ b/c-gull/src/resolve.rs
@@ -1,0 +1,143 @@
+use core::{ffi::CStr, mem::zeroed, ptr::null_mut};
+
+use errno::{set_errno, Errno};
+use libc::{c_char, c_int};
+use rustix::net::{SocketAddrAny, SocketAddrStorage, SocketType};
+
+use rustix::net::{IpAddr, SocketAddrV4, SocketAddrV6};
+use sync_resolve::resolve_host;
+
+extern crate alloc;
+
+#[no_mangle]
+unsafe extern "C" fn getaddrinfo(
+    node: *const c_char,
+    service: *const c_char,
+    hints: *const libc::addrinfo,
+    res: *mut *mut libc::addrinfo,
+) -> c_int {
+    libc!(libc::getaddrinfo(node, service, hints, res));
+
+    assert!(service.is_null(), "service lookups not supported yet");
+    assert!(!node.is_null(), "only name lookups are supported corrently");
+
+    if !hints.is_null() {
+        let hints = &*hints;
+        assert_eq!(hints.ai_flags, 0, "GAI flags hint not supported yet");
+        assert_eq!(hints.ai_family, 0, "GAI family hint not supported yet");
+        assert_eq!(
+            hints.ai_socktype,
+            SocketType::STREAM.as_raw() as _,
+            "only SOCK_STREAM supported currently"
+        );
+        assert_eq!(hints.ai_protocol, 0, "GAI protocl hint not supported yet");
+        assert_eq!(hints.ai_addrlen, 0, "GAI addrlen hint not supported yet");
+        assert!(hints.ai_addr.is_null(), "GAI addr hint not supported yet");
+        assert!(
+            hints.ai_canonname.is_null(),
+            "GAI canonname hint not supported yet"
+        );
+        assert!(hints.ai_next.is_null(), "GAI next hint not supported yet");
+    }
+
+    let host = match CStr::from_ptr(node.cast()).to_str() {
+        Ok(host) => host,
+        Err(_) => {
+            set_errno(Errno(libc::EILSEQ));
+            return libc::EAI_SYSTEM;
+        }
+    };
+
+    let layout = alloc::alloc::Layout::new::<libc::addrinfo>();
+    let addr_layout = alloc::alloc::Layout::new::<SocketAddrStorage>();
+    let mut first: *mut libc::addrinfo = null_mut();
+    let mut prev: *mut libc::addrinfo = null_mut();
+    match resolve_host(host) {
+        Ok(addrs) => {
+            for addr in addrs {
+                let ptr = alloc::alloc::alloc(layout).cast::<libc::addrinfo>();
+                ptr.write(zeroed());
+                let info = &mut *ptr;
+                match addr {
+                    IpAddr::V4(v4) => {
+                        // TODO: Create and write to `SocketAddrV4Storage`?
+                        let storage = alloc::alloc::alloc(addr_layout).cast::<SocketAddrStorage>();
+                        let len = SocketAddrAny::V4(SocketAddrV4::new(v4, 0)).write(storage);
+                        info.ai_addr = storage.cast();
+                        info.ai_addrlen = len.try_into().unwrap();
+                    }
+                    IpAddr::V6(v6) => {
+                        // TODO: Create and write to `SocketAddrV6Storage`?
+                        let storage = alloc::alloc::alloc(addr_layout).cast::<SocketAddrStorage>();
+                        let len = SocketAddrAny::V6(SocketAddrV6::new(v6, 0, 0, 0)).write(storage);
+                        info.ai_addr = storage.cast();
+                        info.ai_addrlen = len.try_into().unwrap();
+                    }
+                }
+                if !prev.is_null() {
+                    (*prev).ai_next = ptr;
+                }
+                prev = ptr;
+                if first.is_null() {
+                    first = ptr;
+                }
+            }
+            *res = first;
+            0
+        }
+        Err(err) => {
+            if let Some(err) = rustix::io::Errno::from_io_error(&err) {
+                set_errno(Errno(err.raw_os_error()));
+                libc::EAI_SYSTEM
+            } else {
+                // TODO: sync-resolve should return a custom error type
+                if err.to_string()
+                    == "failed to resolve host: server responded with error: server failure"
+                    || err.to_string()
+                        == "failed to resolve host: server responded with error: no such name"
+                {
+                    libc::EAI_NONAME
+                } else {
+                    panic!("unknown error: {}", err);
+                }
+            }
+        }
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn freeaddrinfo(mut res: *mut libc::addrinfo) {
+    libc!(libc::freeaddrinfo(res));
+
+    let layout = alloc::alloc::Layout::new::<libc::addrinfo>();
+    let addr_layout = alloc::alloc::Layout::new::<SocketAddrStorage>();
+
+    while !res.is_null() {
+        let addr = (*res).ai_addr;
+        if !addr.is_null() {
+            alloc::alloc::dealloc(addr.cast(), addr_layout);
+        }
+        let old = res;
+        res = (*res).ai_next;
+        alloc::alloc::dealloc(old.cast(), layout);
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn gai_strerror(errcode: c_int) -> *const c_char {
+    libc!(libc::gai_strerror(errcode));
+
+    match errcode {
+        libc::EAI_NONAME => &b"Name does not resolve\0"[..],
+        libc::EAI_SYSTEM => &b"System error\0"[..],
+        _ => panic!("unrecognized gai_strerror {:?}", errcode),
+    }
+    .as_ptr()
+    .cast()
+}
+
+#[no_mangle]
+unsafe extern "C" fn __res_init() -> c_int {
+    libc!(libc::res_init());
+    0
+}

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -15,7 +15,6 @@ libm = "0.2.1"
 rustix = { version = "0.36.1", default-features = false, features = ["fs", "itoa", "net", "param", "process", "rand", "termios", "thread", "time"] }
 memoffset = "0.8.0"
 realpath-ext = { version = "0.1.0", default-features = false }
-sync-resolve = { version = "0.3.0", optional = true }
 origin = { path = "../origin", default-features = false, version = "^0.6.1" }
 log = { version = "0.4.14", default-features = false }
 # We use the libc crate for C ABI types and constants, but we don't depend on
@@ -38,8 +37,6 @@ paste = "1.0.5"
 once_cell = "1.8.0"
 
 [features]
-default = ["threads", "resolve", "net"]
+default = ["threads", "std"]
 threads = ["origin/threads", "origin/set_thread_id"]
-resolve = ["sync-resolve", "std"]
 std = ["rustix/std"]
-net = []

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -85,7 +85,6 @@ mod mem;
 mod mmap;
 
 // net
-#[cfg(feature = "net")]
 mod net;
 
 // process

--- a/c-scape/src/net/mod.rs
+++ b/c-scape/src/net/mod.rs
@@ -1,26 +1,18 @@
 mod inet;
 
-#[cfg(feature = "sync-resolve")]
-use alloc::string::ToString;
 use alloc::vec;
 use core::convert::TryInto;
-use core::ffi::{c_void, CStr};
+use core::ffi::c_void;
 #[cfg(not(target_os = "wasi"))]
-use core::mem::{size_of, zeroed};
-use core::ptr::{copy_nonoverlapping, null_mut};
+use core::mem::size_of;
+use core::ptr::copy_nonoverlapping;
 use core::slice;
 use errno::{set_errno, Errno};
 use libc::{c_char, c_int, c_uint};
 use rustix::fd::{BorrowedFd, IntoRawFd};
-#[cfg(feature = "net")]
 use rustix::net::{
     AcceptFlags, AddressFamily, Ipv4Addr, Ipv6Addr, Protocol, RecvFlags, SendFlags, Shutdown,
     SocketAddrAny, SocketAddrStorage, SocketFlags, SocketType,
-};
-#[cfg(feature = "sync-resolve")]
-use {
-    rustix::net::{IpAddr, SocketAddrV4, SocketAddrV6},
-    sync_resolve::resolve_host,
 };
 
 use crate::convert_res;
@@ -427,137 +419,6 @@ unsafe extern "C" fn setsockopt(
         None => -1,
     }
 }
-
-#[cfg(feature = "sync-resolve")]
-#[no_mangle]
-unsafe extern "C" fn getaddrinfo(
-    node: *const c_char,
-    service: *const c_char,
-    hints: *const libc::addrinfo,
-    res: *mut *mut libc::addrinfo,
-) -> c_int {
-    libc!(libc::getaddrinfo(node, service, hints, res));
-
-    assert!(service.is_null(), "service lookups not supported yet");
-    assert!(!node.is_null(), "only name lookups are supported corrently");
-
-    if !hints.is_null() {
-        let hints = &*hints;
-        assert_eq!(hints.ai_flags, 0, "GAI flags hint not supported yet");
-        assert_eq!(hints.ai_family, 0, "GAI family hint not supported yet");
-        assert_eq!(
-            hints.ai_socktype,
-            SocketType::STREAM.as_raw() as _,
-            "only SOCK_STREAM supported currently"
-        );
-        assert_eq!(hints.ai_protocol, 0, "GAI protocl hint not supported yet");
-        assert_eq!(hints.ai_addrlen, 0, "GAI addrlen hint not supported yet");
-        assert!(hints.ai_addr.is_null(), "GAI addr hint not supported yet");
-        assert!(
-            hints.ai_canonname.is_null(),
-            "GAI canonname hint not supported yet"
-        );
-        assert!(hints.ai_next.is_null(), "GAI next hint not supported yet");
-    }
-
-    let host = match CStr::from_ptr(node.cast()).to_str() {
-        Ok(host) => host,
-        Err(_) => {
-            set_errno(Errno(libc::EILSEQ));
-            return libc::EAI_SYSTEM;
-        }
-    };
-
-    let layout = alloc::alloc::Layout::new::<libc::addrinfo>();
-    let addr_layout = alloc::alloc::Layout::new::<SocketAddrStorage>();
-    let mut first: *mut libc::addrinfo = null_mut();
-    let mut prev: *mut libc::addrinfo = null_mut();
-    match resolve_host(host) {
-        Ok(addrs) => {
-            for addr in addrs {
-                let ptr = alloc::alloc::alloc(layout).cast::<libc::addrinfo>();
-                ptr.write(zeroed());
-                let info = &mut *ptr;
-                match addr {
-                    IpAddr::V4(v4) => {
-                        // TODO: Create and write to `SocketAddrV4Storage`?
-                        let storage = alloc::alloc::alloc(addr_layout).cast::<SocketAddrStorage>();
-                        let len = SocketAddrAny::V4(SocketAddrV4::new(v4, 0)).write(storage);
-                        info.ai_addr = storage.cast();
-                        info.ai_addrlen = len.try_into().unwrap();
-                    }
-                    IpAddr::V6(v6) => {
-                        // TODO: Create and write to `SocketAddrV6Storage`?
-                        let storage = alloc::alloc::alloc(addr_layout).cast::<SocketAddrStorage>();
-                        let len = SocketAddrAny::V6(SocketAddrV6::new(v6, 0, 0, 0)).write(storage);
-                        info.ai_addr = storage.cast();
-                        info.ai_addrlen = len.try_into().unwrap();
-                    }
-                }
-                if !prev.is_null() {
-                    (*prev).ai_next = ptr;
-                }
-                prev = ptr;
-                if first.is_null() {
-                    first = ptr;
-                }
-            }
-            *res = first;
-            0
-        }
-        Err(err) => {
-            if let Some(err) = rustix::io::Errno::from_io_error(&err) {
-                set_errno(Errno(err.raw_os_error()));
-                libc::EAI_SYSTEM
-            } else {
-                // TODO: sync-resolve should return a custom error type
-                if err.to_string()
-                    == "failed to resolve host: server responded with error: server failure"
-                    || err.to_string()
-                        == "failed to resolve host: server responded with error: no such name"
-                {
-                    libc::EAI_NONAME
-                } else {
-                    panic!("unknown error: {}", err);
-                }
-            }
-        }
-    }
-}
-
-#[cfg(feature = "sync-resolve")]
-#[no_mangle]
-unsafe extern "C" fn freeaddrinfo(mut res: *mut libc::addrinfo) {
-    libc!(libc::freeaddrinfo(res));
-
-    let layout = alloc::alloc::Layout::new::<libc::addrinfo>();
-    let addr_layout = alloc::alloc::Layout::new::<SocketAddrStorage>();
-
-    while !res.is_null() {
-        let addr = (*res).ai_addr;
-        if !addr.is_null() {
-            alloc::alloc::dealloc(addr.cast(), addr_layout);
-        }
-        let old = res;
-        res = (*res).ai_next;
-        alloc::alloc::dealloc(old.cast(), layout);
-    }
-}
-
-#[cfg(feature = "sync-resolve")]
-#[no_mangle]
-unsafe extern "C" fn gai_strerror(errcode: c_int) -> *const c_char {
-    libc!(libc::gai_strerror(errcode));
-
-    match errcode {
-        libc::EAI_NONAME => &b"Name does not resolve\0"[..],
-        libc::EAI_SYSTEM => &b"System error\0"[..],
-        _ => panic!("unrecognized gai_strerror {:?}", errcode),
-    }
-    .as_ptr()
-    .cast()
-}
-
 #[cfg(not(target_os = "wasi"))]
 #[no_mangle]
 unsafe extern "C" fn gethostname(name: *mut c_char, len: usize) -> c_int {
@@ -759,11 +620,4 @@ unsafe extern "C" fn socketpair(
         }
         None => -1,
     }
-}
-
-#[cfg(feature = "sync-resolve")]
-#[no_mangle]
-unsafe extern "C" fn __res_init() -> c_int {
-    libc!(libc::res_init());
-    0
 }


### PR DESCRIPTION
Moves resolve into c-gull from c-scape as it requires `sync-resolve` which in turn requires std. Also, removes the net feature. This is because the rustix already was building net, and it simplifies the c-gull passthrough.