### PR TITLE
Use updated atomic ptr api

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,17 +30,17 @@ jobs:
         include:
           - build: ubuntu
             os: ubuntu-latest
-            rust: nightly-2022-11-17
+            rust: nightly-2023-03-02
             host_target: x86_64-unknown-linux-gnu
             mustang_target: x86_64-mustang-linux-gnu
           - build: ubuntu-18.04
             os: ubuntu-18.04
-            rust: nightly-2022-11-17
+            rust: nightly-2023-03-02
             host_target: x86_64-unknown-linux-gnu
             mustang_target: x86_64-mustang-linux-gnu
           - build: i686-linux
             os: ubuntu-latest
-            rust: nightly-2022-11-17
+            rust: nightly-2023-03-02
             target: i686-unknown-linux-gnu
             gcc_package: gcc-i686-linux-gnu
             gcc: i686-linux-gnu-gcc
@@ -49,7 +49,7 @@ jobs:
             mustang_target: i686-mustang-linux-gnu
           - build: aarch64-linux
             os: ubuntu-latest
-            rust: nightly-2022-11-17
+            rust: nightly-2023-03-02
             target: aarch64-unknown-linux-gnu
             gcc_package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
@@ -59,7 +59,7 @@ jobs:
             mustang_target: aarch64-mustang-linux-gnu
           - build: riscv64-linux
             os: ubuntu-latest
-            rust: nightly-2022-11-17
+            rust: nightly-2023-03-02
             target: riscv64gc-unknown-linux-gnu
             gcc_package: gcc-riscv64-linux-gnu
             gcc: riscv64-linux-gnu-gcc
@@ -140,28 +140,28 @@ jobs:
 
     - name: Install rust-src
       run: |
-        rustup component add rust-src --toolchain nightly-2022-11-17-x86_64-unknown-linux-gnu
+        rustup component add rust-src --toolchain nightly-2023-03-02-x86_64-unknown-linux-gnu
 
     - name: cargo check non-mustang
       run: |
         # Check that the code compiles on non-mustang targets.
-        cargo +nightly-2022-11-17 check --all --target=${{ matrix.host_target }}
+        cargo +nightly-2023-03-02 check --all --target=${{ matrix.host_target }}
 
     - name: cargo test
       run: |
-        cargo +nightly-2022-11-17 test --verbose -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json -- ${{ matrix.test_args }} -- --nocapture
+        cargo +nightly-2023-03-02 test --verbose -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json -- ${{ matrix.test_args }} -- --nocapture
       env:
         RUST_BACKTRACE: 1
 
     - name: cargo test --release
       run: |
-        cargo +nightly-2022-11-17 test --verbose --release -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json  -- ${{ matrix.test_args }}
+        cargo +nightly-2023-03-02 test --verbose --release -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json  -- ${{ matrix.test_args }}
       env:
         RUST_BACKTRACE: 1
 
     - name: test mustang_use_libc
       run: |
-        RUSTFLAGS=--cfg=mustang_use_libc cargo +nightly-2022-11-17 check --workspace -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json
+        RUSTFLAGS=--cfg=mustang_use_libc cargo +nightly-2023-03-02 check --workspace -Z build-std --target=mustang/target-specs/${{ matrix.mustang_target }}.json
       env:
         RUST_BACKTRACE: 1
 
@@ -182,27 +182,27 @@ jobs:
     - name: test libc-replacement in non-mustang mode
       working-directory: test-crates/libc-replacement
       run: |
-        cargo +nightly-2022-11-17 run --target=${{ matrix.host_target }}
+        cargo +nightly-2023-03-02 run --target=${{ matrix.host_target }}
       env:
         RUST_BACKTRACE: 1
 
     - name: test origin-as-just-a-library in non-mustang mode
       working-directory: test-crates/origin-as-just-a-library
       run: |
-        cargo +nightly-2022-11-17 run --target=${{ matrix.host_target }}
+        cargo +nightly-2023-03-02 run --target=${{ matrix.host_target }}
       env:
         RUST_BACKTRACE: 1
 
     - name: test mustang-nostd as program
       working-directory: test-crates/mustang-nostd
       run: |
-        cargo +nightly-2022-11-17 run -Zbuild-std=core,alloc --target=../../mustang/target-specs/${{ matrix.mustang_target }}.json
+        cargo +nightly-2023-03-02 run -Zbuild-std=core,alloc --target=../../mustang/target-specs/${{ matrix.mustang_target }}.json
       env:
         RUST_BACKTRACE: 1
 
     - name: test mustang-nostd as tests
       working-directory: test-crates/mustang-nostd
       run: |
-        cargo +nightly-2022-11-17 test -Zbuild-std=core,alloc,test,std --target=../../mustang/target-specs/${{ matrix.mustang_target }}.json
+        cargo +nightly-2023-03-02 test -Zbuild-std=core,alloc,test,std --target=../../mustang/target-specs/${{ matrix.mustang_target }}.json
       env:
         RUST_BACKTRACE: 1

--- a/origin/src/sync/wait_wake.rs
+++ b/origin/src/sync/wait_wake.rs
@@ -40,7 +40,7 @@ pub fn futex_wait(futex: &AtomicU32, expected: u32, timeout: Option<Duration>) -
         // absolute time rather than a relative time.
         let r = unsafe {
             rustix::thread::futex(
-                futex.as_mut_ptr(),
+                futex.as_ptr(),
                 FutexOperation::WaitBitset,
                 FutexFlags::PRIVATE,
                 expected,
@@ -66,7 +66,7 @@ pub fn futex_wake(futex: &AtomicU32) -> bool {
     use core::ptr::{null, null_mut};
     unsafe {
         rustix::thread::futex(
-            futex.as_mut_ptr(),
+            futex.as_ptr(),
             FutexOperation::Wake,
             FutexFlags::PRIVATE,
             1,
@@ -83,7 +83,7 @@ pub fn futex_wake_all(futex: &AtomicU32) {
     use core::ptr::{null, null_mut};
     unsafe {
         rustix::thread::futex(
-            futex.as_mut_ptr(),
+            futex.as_ptr(),
             FutexOperation::Wake,
             FutexFlags::PRIVATE,
             i32::MAX as u32,

--- a/origin/src/threads.rs
+++ b/origin/src/threads.rs
@@ -617,7 +617,7 @@ pub fn create_thread(
             | CloneFlags::CHILD_CLEARTID
             | CloneFlags::CHILD_SETTID
             | CloneFlags::PARENT_SETTID;
-        let thread_id_ptr = (*metadata).thread.thread_id.as_mut_ptr();
+        let thread_id_ptr = (*metadata).thread.thread_id.as_ptr();
         #[cfg(target_arch = "x86_64")]
         let clone_res = clone(
             flags.bits(),
@@ -729,7 +729,7 @@ unsafe fn wait_for_thread_exit(thread: Thread) {
         // as arranged by the `CloneFlags::CHILD_CLEARTID` flag,
         // and Linux doesn't use the private flag for the wake.
         match futex(
-            thread_id.as_mut_ptr(),
+            thread_id.as_ptr(),
             FutexOperation::Wait,
             FutexFlags::empty(),
             id_value.as_raw_nonzero().get(),

--- a/test-crates/mustang-nostd/src/main.rs
+++ b/test-crates/mustang-nostd/src/main.rs
@@ -1,6 +1,4 @@
 #![feature(lang_items)]
-// TODO: Remove when updating toolchain for tests
-#![feature(default_alloc_error_handler)]
 #![no_std]
 // When testing we do not want to use our main function
 #![cfg_attr(not(test), no_main)]

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -40,7 +40,7 @@ fn test_example(name: &str, features: &str, stdout: &str, stderr: &str) {
     let env = "gnu";
 
     let mut command = Command::new("cargo");
-    command.arg("+nightly-2022-11-17").arg("run").arg("--quiet");
+    command.arg("+nightly-2023-03-02").arg("run").arg("--quiet");
     if !features.is_empty() {
         command
             .arg("--no-default-features")


### PR DESCRIPTION
Origin fails to compile on latest nightly due to a [rename](https://github.com/rust-lang/rust/pull/107736_) of `as_mut_ptr` in the atomic ptr api. This fixes that to use `as_ptr`. Also updates the test toolchain to latest nightly.