### PR TITLE
Check if rustup is installed for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ libc = "0.2.138"
 # Test that the ctor crate works under mustang.
 ctor = "0.1.21"
 
+# Check if rustup is installed for tests
+which = "4.4.0"
+
 # Test that the core_simd crate works under mustang.
 # TODO: Re-enable this when core_simd works on Rust nightly.
 #core_simd = { git = "https://github.com/rust-lang/portable-simd" }

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -40,7 +40,10 @@ fn test_example(name: &str, features: &str, stdout: &str, stderr: &str) {
     let env = "gnu";
 
     let mut command = Command::new("cargo");
-    command.arg("+nightly-2023-03-02").arg("run").arg("--quiet");
+    if which::which("rustup").is_ok() {
+        command.arg("+nightly-2023-03-02");
+    }
+    command.arg("run").arg("--quiet");
     if !features.is_empty() {
         command
             .arg("--no-default-features")


### PR DESCRIPTION
Should fix running tests when not using rustup for toolchain management. Closes https://github.com/sunfishcode/mustang/issues/161