### PR TITLE
Implement `epoll`

### DIFF
--- a/c-scape/src/io/mod.rs
+++ b/c-scape/src/io/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(not(target_os = "wasi"))]
 mod dup;
-// #[cfg(any(target_os = "android", target_os = "linux"))]
-// mod epoll;
+#[cfg(any(target_os = "android", target_os = "linux"))]
+mod epoll;
 mod isatty;
 mod pipe;
 mod poll;


### PR DESCRIPTION
Use the new epoll API from bytecodealliance/rustix#487.

Fixes #86.