### PR TITLE
Add stubs for `*getxattr` functions.

### DIFF
--- a/c-scape/src/fs/mod.rs
+++ b/c-scape/src/fs/mod.rs
@@ -17,6 +17,7 @@ mod symlink;
 mod sync;
 mod truncate;
 mod utime;
+mod xattr;
 
 use core::ffi::CStr;
 use rustix::fd::BorrowedFd;

--- a/c-scape/src/fs/xattr.rs
+++ b/c-scape/src/fs/xattr.rs
@@ -1,0 +1,43 @@
+//! Extended attributes.
+//!
+//! These are not yet implemented in rustix. For now, use stubs so that
+//! programs that use them can be linked.
+
+use crate::{set_errno, Errno};
+use libc::{c_char, c_int, c_void, size_t, ssize_t};
+
+#[no_mangle]
+unsafe extern "C" fn getxattr(
+    path: *const c_char,
+    name: *const c_char,
+    value: *mut c_void,
+    size: size_t,
+) -> ssize_t {
+    libc!(libc::getxattr(path, name, value, size));
+    set_errno(Errno(libc::ENOTSUP));
+    -1
+}
+
+#[no_mangle]
+unsafe extern "C" fn lgetxattr(
+    path: *const c_char,
+    name: *const c_char,
+    value: *mut c_void,
+    size: size_t,
+) -> ssize_t {
+    libc!(libc::lgetxattr(path, name, value, size));
+    set_errno(Errno(libc::ENOTSUP));
+    -1
+}
+
+#[no_mangle]
+unsafe extern "C" fn fgetxattr(
+    fd: c_int,
+    name: *const c_char,
+    value: *mut c_void,
+    size: size_t,
+) -> ssize_t {
+    libc!(libc::fgetxattr(fd, name, value, size));
+    set_errno(Errno(libc::ENOTSUP));
+    -1
+}

--- a/c-scape/src/fs/xattr.rs
+++ b/c-scape/src/fs/xattr.rs
@@ -41,3 +41,24 @@ unsafe extern "C" fn fgetxattr(
     set_errno(Errno(libc::ENOTSUP));
     -1
 }
+
+#[no_mangle]
+unsafe extern "C" fn listxattr(path: *const c_char, list: *mut c_char, size: size_t) -> ssize_t {
+    libc!(libc::listxattr(path, list, size));
+    set_errno(Errno(libc::ENOTSUP));
+    -1
+}
+
+#[no_mangle]
+unsafe extern "C" fn llistxattr(path: *const c_char, list: *mut c_char, size: size_t) -> ssize_t {
+    libc!(libc::llistxattr(path, list, size));
+    set_errno(Errno(libc::ENOTSUP));
+    -1
+}
+
+#[no_mangle]
+unsafe extern "C" fn flistxattr(fd: c_int, list: *mut c_char, size: size_t) -> ssize_t {
+    libc!(libc::flistxattr(fd, list, size));
+    set_errno(Errno(libc::ENOTSUP));
+    -1
+}


### PR DESCRIPTION
These aren't implemented in rustix yet, but these stubs should be enough to get simple things working.