### PR TITLE
Implement `tzset`, `timegm`, and `timelocal`.

### DIFF
--- a/c-gull/src/lib.rs
+++ b/c-gull/src/lib.rs
@@ -2,7 +2,6 @@
 #![no_builtins] // don't let LLVM optimize our `memcpy` into a `memcpy` call
 #![feature(strict_provenance)]
 #![feature(c_variadic)]
-#![feature(hash_set_entry)]
 #![deny(fuzzy_provenance_casts)]
 #![deny(lossy_provenance_casts)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/c-gull/src/lib.rs
+++ b/c-gull/src/lib.rs
@@ -2,6 +2,7 @@
 #![no_builtins] // don't let LLVM optimize our `memcpy` into a `memcpy` call
 #![feature(strict_provenance)]
 #![feature(c_variadic)]
+#![feature(hash_set_entry)]
 #![deny(fuzzy_provenance_casts)]
 #![deny(lossy_provenance_casts)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/c-gull/src/time.rs
+++ b/c-gull/src/time.rs
@@ -248,11 +248,10 @@ fn date_time_to_tm(date_time: DateTime) -> tm {
     let tm_zone = {
         let mut timezone_names = TIMEZONE_NAMES.lock().unwrap();
         timezone_names.get_or_init(|| HashSet::new());
-        timezone_names
-            .get_mut()
-            .unwrap()
-            .get_or_insert(CString::new(local_time_type.time_zone_designation()).unwrap())
-            .as_ptr()
+        let cstr = CString::new(local_time_type.time_zone_designation()).unwrap();
+        // TODO: Use `get_or_insert` when `hash_set_entry` is stabilized.
+        timezone_names.get_mut().unwrap().insert(cstr.clone());
+        timezone_names.get().unwrap().get(&cstr).unwrap().as_ptr()
     };
 
     tm {

--- a/c-gull/src/time.rs
+++ b/c-gull/src/time.rs
@@ -1,24 +1,39 @@
 //! Time and date conversion routines.
 //!
-//! This code is highly experimental and contains some FIXMEs.
+//! This code is highly experimental.
 
 use errno::{set_errno, Errno};
-use libc::{c_char, time_t, tm};
-use std::ptr::{null_mut, write};
+use libc::{c_char, c_int, c_long, time_t, tm};
+use std::cell::OnceCell;
+use std::collections::HashSet;
+use std::ffi::CString;
+use std::ptr::{self, null_mut};
+use std::sync::{Mutex, MutexGuard};
 use tz::error::{TzError, TzFileError, TzStringError};
+use tz::timezone::TransitionRule;
 use tz::{DateTime, LocalTimeType, TimeZone};
 
 // These things aren't really thread-safe, but they're implementing C ABIs and
 // the C rule is, it's up to the user to ensure that none of the bad things
 // happen.
-struct SyncTzName([*mut c_char; 2]);
-unsafe impl Sync for SyncTzName {}
-
 struct SyncTm(tm);
 unsafe impl Sync for SyncTm {}
 
+// `tzname`, `timezone`, and `daylight` are guarded by `TIMEZONE_LOCK`.
+struct SyncTzName([*mut c_char; 2]);
+unsafe impl Sync for SyncTzName {}
+
+// Hold `TIMEZONE_LOCK` when updating `tzname`, `timezone`, and `daylight`.
+static TIMEZONE_LOCK: Mutex<(Option<CString>, Option<CString>)> = Mutex::new((None, None));
 #[no_mangle]
 static mut tzname: SyncTzName = SyncTzName([null_mut(), null_mut()]);
+#[no_mangle]
+static mut timezone: c_long = 0;
+#[no_mangle]
+static mut daylight: c_int = 0;
+
+// Name storage for the `tm_zone` field.
+static TIMEZONE_NAMES: Mutex<OnceCell<HashSet<CString>>> = Mutex::new(OnceCell::new());
 
 #[no_mangle]
 unsafe extern "C" fn gmtime(time: *const time_t) -> *mut tm {
@@ -42,7 +57,7 @@ unsafe extern "C" fn gmtime_r(time: *const time_t, result: *mut tm) -> *mut tm {
         }
     };
 
-    write(result, date_time_to_tm(date_time, utc_time_type));
+    ptr::write(result, date_time_to_tm(date_time));
 
     result
 }
@@ -62,7 +77,7 @@ unsafe extern "C" fn localtime_r(time: *const time_t, result: *mut tm) -> *mut t
     let time_zone_local = match TimeZone::local() {
         Ok(time_zone_local) => time_zone_local,
         Err(err) => {
-            set_errno(Errno(tz_error_to_errno(err)));
+            set_errno(tz_error_to_errno(err));
             return null_mut();
         }
     };
@@ -83,104 +98,163 @@ unsafe extern "C" fn localtime_r(time: *const time_t, result: *mut tm) -> *mut t
         }
     };
 
-    write(result, date_time_to_tm(date_time, *local_time_type));
+    ptr::write(result, date_time_to_tm(date_time));
 
     result
+}
+
+fn tm_to_date_time(tm: &tm, time_zone: &TimeZone) -> Result<DateTime, Errno> {
+    let tm_year = (*tm).tm_year;
+    let tm_mon: u8 = match (*tm).tm_mon.try_into() {
+        Ok(tm_mon) => tm_mon,
+        Err(_err) => return Err(Errno(libc::EOVERFLOW)),
+    };
+    let tm_mday = match (*tm).tm_mday.try_into() {
+        Ok(tm_mday) => tm_mday,
+        Err(_err) => return Err(Errno(libc::EOVERFLOW)),
+    };
+    let tm_hour = match (*tm).tm_hour.try_into() {
+        Ok(tm_hour) => tm_hour,
+        Err(_err) => return Err(Errno(libc::EOVERFLOW)),
+    };
+    let tm_min = match (*tm).tm_min.try_into() {
+        Ok(tm_min) => tm_min,
+        Err(_err) => return Err(Errno(libc::EOVERFLOW)),
+    };
+    let tm_sec = match (*tm).tm_sec.try_into() {
+        Ok(tm_sec) => tm_sec,
+        Err(_err) => return Err(Errno(libc::EOVERFLOW)),
+    };
+
+    let utc;
+    let (std_time_type, dst_time_type) = if let Some(extra_rule) = time_zone.as_ref().extra_rule() {
+        match extra_rule {
+            TransitionRule::Fixed(local_time_type) => (local_time_type, None),
+            TransitionRule::Alternate(alternate_time_type) => {
+                (alternate_time_type.std(), Some(alternate_time_type.dst()))
+            }
+        }
+    } else {
+        utc = LocalTimeType::utc();
+        (&utc, None)
+    };
+
+    let date_time = match (*tm).tm_isdst {
+        tm_isdst if tm_isdst < 0 => {
+            match DateTime::find(
+                tm_year + 1900,
+                tm_mon + 1,
+                tm_mday,
+                tm_hour,
+                tm_min,
+                tm_sec,
+                0,
+                time_zone.as_ref(),
+            ) {
+                Ok(found) => {
+                    match found.unique() {
+                        Some(date_time) => date_time,
+                        None => {
+                            // It's not clear what we should do here, so for
+                            // now just be conservative.
+                            return Err(Errno(libc::EIO));
+                        }
+                    }
+                }
+                Err(_err) => return Err(Errno(libc::EIO)),
+            }
+        }
+        tm_isdst => {
+            let time_type = if tm_isdst > 0 {
+                std_time_type
+            } else {
+                dst_time_type.unwrap_or(std_time_type)
+            };
+            match DateTime::new(
+                tm_year + 1900,
+                tm_mon + 1,
+                tm_mday,
+                tm_hour,
+                tm_min,
+                tm_sec,
+                0,
+                *time_type,
+            ) {
+                Ok(date_time) => date_time,
+                Err(_err) => return Err(Errno(libc::EIO)),
+            }
+        }
+    };
+
+    Ok(date_time)
 }
 
 #[no_mangle]
 unsafe extern "C" fn mktime(tm: *mut tm) -> time_t {
     libc!(libc::mktime(tm));
 
+    let mut lock = TIMEZONE_LOCK.lock().unwrap();
+
+    clear_timezone(&mut lock);
+
     let time_zone_local = match TimeZone::local() {
         Ok(time_zone_local) => time_zone_local,
         Err(err) => {
-            set_errno(Errno(tz_error_to_errno(err)));
+            set_errno(tz_error_to_errno(err));
             return -1;
         }
     };
 
-    let current_local_time_type = match time_zone_local.find_current_local_time_type() {
-        Ok(local_time_type) => local_time_type,
-        Err(_err) => {
-            set_errno(Errno(libc::EIO));
-            return -1;
-        }
-    };
+    let utc;
+    let (std_time_type, dst_time_type) =
+        if let Some(extra_rule) = time_zone_local.as_ref().extra_rule() {
+            match extra_rule {
+                TransitionRule::Fixed(local_time_type) => (local_time_type, None),
+                TransitionRule::Alternate(alternate_time_type) => {
+                    (alternate_time_type.std(), Some(alternate_time_type.dst()))
+                }
+            }
+        } else {
+            utc = LocalTimeType::utc();
+            (&utc, None)
+        };
 
-    let tm_year = (*tm).tm_year;
-    let tm_mon: u8 = match (*tm).tm_mon.try_into() {
-        Ok(tm_mon) => tm_mon,
-        Err(_err) => {
-            set_errno(Errno(libc::EOVERFLOW));
-            return -1;
-        }
-    };
-    let tm_mday = match (*tm).tm_mday.try_into() {
-        Ok(tm_mday) => tm_mday,
-        Err(_err) => {
-            set_errno(Errno(libc::EOVERFLOW));
-            return -1;
-        }
-    };
-    let tm_hour = match (*tm).tm_hour.try_into() {
-        Ok(tm_hour) => tm_hour,
-        Err(_err) => {
-            set_errno(Errno(libc::EOVERFLOW));
-            return -1;
-        }
-    };
-    let tm_min = match (*tm).tm_min.try_into() {
-        Ok(tm_min) => tm_min,
-        Err(_err) => {
-            set_errno(Errno(libc::EOVERFLOW));
-            return -1;
-        }
-    };
-    let tm_sec = match (*tm).tm_sec.try_into() {
-        Ok(tm_sec) => tm_sec,
-        Err(_err) => {
-            set_errno(Errno(libc::EOVERFLOW));
-            return -1;
-        }
-    };
-
-    // FIXME: What should we do with tm.tm_isdst?
-
-    // Create a new date time.
-    let date_time = match DateTime::new(
-        tm_year + 1900,
-        tm_mon + 1,
-        tm_mday,
-        tm_hour,
-        tm_min,
-        tm_sec,
-        0,
-        *current_local_time_type,
-    ) {
+    let date_time = match tm_to_date_time(&*tm, &time_zone_local) {
         Ok(date_time) => date_time,
-        Err(_err) => {
-            set_errno(Errno(libc::EIO));
+        Err(errno) => {
+            set_errno(errno);
             return -1;
         }
     };
 
-    let result = date_time.unix_time();
-
-    set_tzname(current_local_time_type);
-
-    write(tm, date_time_to_tm(date_time, *current_local_time_type));
-
-    match result.try_into() {
-        Ok(result) => result,
+    let unix_time = match date_time.unix_time().try_into() {
+        Ok(unix_time) => unix_time,
         Err(_err) => {
             set_errno(Errno(libc::EOVERFLOW));
             -1
         }
-    }
+    };
+
+    ptr::write(tm, date_time_to_tm(date_time));
+
+    set_timezone(&mut lock, std_time_type, dst_time_type);
+
+    unix_time
 }
 
-fn date_time_to_tm(date_time: DateTime, local_time_type: LocalTimeType) -> tm {
+fn date_time_to_tm(date_time: DateTime) -> tm {
+    let local_time_type = date_time.local_time_type();
+
+    let tm_zone = {
+        let mut timezone_names = TIMEZONE_NAMES.lock().unwrap();
+        timezone_names.get_or_init(|| HashSet::new());
+        timezone_names
+            .get_mut()
+            .unwrap()
+            .get_or_insert(CString::new(local_time_type.time_zone_designation()).unwrap())
+            .as_ptr()
+    };
+
     tm {
         tm_year: date_time.year() - 1900,
         tm_mon: (date_time.month() - 1).into(),
@@ -192,7 +266,7 @@ fn date_time_to_tm(date_time: DateTime, local_time_type: LocalTimeType) -> tm {
         tm_yday: date_time.year_day().into(),
         tm_isdst: if local_time_type.is_dst() { 1 } else { 0 },
         tm_gmtoff: local_time_type.ut_offset().into(),
-        tm_zone: b"FIXME(c-gull)\0".as_ptr().cast(),
+        tm_zone,
     }
 }
 
@@ -212,19 +286,16 @@ const fn blank_tm() -> tm {
     }
 }
 
-unsafe fn set_tzname(_time_zone_local: &LocalTimeType) {
-    tzname.0[0] = "FIXME(c-gull)\0".as_ptr() as _;
-    tzname.0[1] = "FIXME(c-gull)\0".as_ptr() as _;
-}
-
-fn tz_error_to_errno(err: TzError) -> i32 {
+fn tz_error_to_errno(err: TzError) -> Errno {
     match err {
-        TzError::IoError(err) => err.raw_os_error().unwrap_or(libc::EIO),
-        TzError::TzFileError(TzFileError::IoError(err)) => err.raw_os_error().unwrap_or(libc::EIO),
-        TzError::TzStringError(TzStringError::IoError(err)) => {
-            err.raw_os_error().unwrap_or(libc::EIO)
+        TzError::IoError(err) => Errno(err.raw_os_error().unwrap_or(libc::EIO)),
+        TzError::TzFileError(TzFileError::IoError(err)) => {
+            Errno(err.raw_os_error().unwrap_or(libc::EIO))
         }
-        _ => libc::EIO,
+        TzError::TzStringError(TzStringError::IoError(err)) => {
+            Errno(err.raw_os_error().unwrap_or(libc::EIO))
+        }
+        _ => Errno(libc::EIO),
     }
 }
 
@@ -232,5 +303,115 @@ fn tz_error_to_errno(err: TzError) -> i32 {
 unsafe extern "C" fn timegm(tm: *mut tm) -> time_t {
     libc!(libc::timegm(tm));
 
-    unimplemented!("timegm")
+    let time_zone_utc = TimeZone::utc();
+
+    let date_time = match tm_to_date_time(&*tm, &time_zone_utc) {
+        Ok(date_time) => date_time,
+        Err(errno) => {
+            set_errno(errno);
+            return -1;
+        }
+    };
+
+    let unix_time = match date_time.unix_time().try_into() {
+        Ok(unix_time) => unix_time,
+        Err(_err) => {
+            set_errno(Errno(libc::EOVERFLOW));
+            -1
+        }
+    };
+
+    unix_time
+}
+
+#[no_mangle]
+unsafe extern "C" fn timelocal(tm: *mut tm) -> time_t {
+    //libc!(libc::timelocal(tm)); // TODO: upstream
+
+    let time_zone_local = match TimeZone::local() {
+        Ok(time_zone_local) => time_zone_local,
+        Err(err) => {
+            set_errno(tz_error_to_errno(err));
+            return -1;
+        }
+    };
+
+    let date_time = match tm_to_date_time(&*tm, &time_zone_local) {
+        Ok(date_time) => date_time,
+        Err(errno) => {
+            set_errno(errno);
+            return -1;
+        }
+    };
+
+    let unix_time = match date_time.unix_time().try_into() {
+        Ok(unix_time) => unix_time,
+        Err(_err) => {
+            set_errno(Errno(libc::EOVERFLOW));
+            -1
+        }
+    };
+
+    unix_time
+}
+
+#[no_mangle]
+unsafe extern "C" fn tzset() {
+    //libc!(libc::tzset()); // TODO: upstream
+
+    let mut lock = TIMEZONE_LOCK.lock().unwrap();
+
+    clear_timezone(&mut lock);
+
+    let time_zone_local = match TimeZone::local() {
+        Ok(time_zone_local) => time_zone_local,
+        Err(_err) => return,
+    };
+
+    if let Some(extra_rule) = time_zone_local.as_ref().extra_rule() {
+        match extra_rule {
+            TransitionRule::Fixed(local_time_type) => {
+                set_timezone(&mut lock, local_time_type, None);
+            }
+            TransitionRule::Alternate(alternate_time_type) => {
+                let std = alternate_time_type.std();
+                let dst = alternate_time_type.dst();
+                set_timezone(&mut lock, std, Some(dst));
+            }
+        }
+    }
+}
+
+unsafe fn set_timezone(
+    guard: &mut MutexGuard<(Option<CString>, Option<CString>)>,
+    std: &LocalTimeType,
+    dst: Option<&LocalTimeType>,
+) {
+    guard.0 = Some(CString::new(std.time_zone_designation()).unwrap());
+    tzname.0[0] = guard.0.as_ref().unwrap().as_ptr() as *mut c_char;
+
+    match dst {
+        Some(dst) => {
+            guard.1 = Some(CString::new(dst.time_zone_designation()).unwrap());
+            tzname.0[1] = guard.1.as_ref().unwrap().as_ptr() as *mut c_char;
+            daylight = 1;
+        }
+        None => {
+            guard.1 = None;
+            tzname.0[1] = guard.0.as_ref().unwrap().as_ptr() as *mut c_char;
+            daylight = 0;
+        }
+    }
+
+    let ut_offset = std.ut_offset();
+    timezone = -c_long::from(ut_offset);
+}
+
+unsafe fn clear_timezone(guard: &mut MutexGuard<(Option<CString>, Option<CString>)>) {
+    guard.0 = None;
+    guard.1 = None;
+    tzname.0[0] = null_mut();
+    tzname.0[1] = null_mut();
+    timezone = 0;
+    daylight = 0;
 }

--- a/c-gull/src/time.rs
+++ b/c-gull/src/time.rs
@@ -166,9 +166,9 @@ fn tm_to_date_time(tm: &tm, time_zone: &TimeZone) -> Result<DateTime, Errno> {
         }
         tm_isdst => {
             let time_type = if tm_isdst > 0 {
-                std_time_type
-            } else {
                 dst_time_type.unwrap_or(std_time_type)
+            } else {
+                std_time_type
             };
             match DateTime::new(
                 tm_year + 1900,


### PR DESCRIPTION
This also revamps the time code, fixing the FIXMEs. This code is still experimental, but it is enough to support coreutils `date`, `pr`, and `touch`.