### PR TITLE
Enable the `+v8a` feature on aarch64.

### DIFF
--- a/mustang/target-specs/aarch64-mustang-linux-gnu.json
+++ b/mustang/target-specs/aarch64-mustang-linux-gnu.json
@@ -4,6 +4,7 @@
   "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
   "dynamic-linking": false,
   "env": "gnu",
+  "features": "+v8a",
   "has-rpath": true,
   "has-thread-local": true,
   "is-builtin": false,


### PR DESCRIPTION
This is enabled in the target spec generated by
`rustc +nightly -Z unstable-options --print target-spec-json --target aarch64-unknown-linux-gnu`

so enable it for Mustang too.