### PR TITLE
Improved `sigaction` support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Known limitations in `mustang` include:
 
  - No support for dynamic linking yet.
  - Many missing features needed for libraries written in C.
+ - Custom signal handlers don't work yet.
 
 ## Background
 

--- a/c-gull/Cargo.toml
+++ b/c-gull/Cargo.toml
@@ -20,7 +20,7 @@ tz-rs = { version = "0.6.11", optional = true }
 printf-compat = { version = "0.1.1", optional = true }
 sync-resolve = { version = "0.3.0", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
-rustix = { version = "0.37.12", default-features = false, optional = true, features = ["fs", "itoa", "net", "param", "process", "rand", "termios", "thread", "time"] }
+rustix = { version = "0.37.13", default-features = false, optional = true, features = ["fs", "itoa", "net", "param", "process", "rand", "termios", "thread", "time"] }
 
 [dev-dependencies]
 libc = "0.2.138"

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 libm = "0.2.1"
-rustix = { version = "0.37.12", default-features = false, features = ["fs", "itoa", "net", "param", "process", "rand", "termios", "thread", "time"] }
+rustix = { version = "0.37.13", default-features = false, features = ["fs", "itoa", "net", "param", "process", "rand", "runtime", "termios", "thread", "time"] }
 memoffset = "0.8.0"
 realpath-ext = { version = "0.1.0", default-features = false }
 origin = { path = "../origin", default-features = false, version = "^0.8.6" }

--- a/c-scape/src/signal/mod.rs
+++ b/c-scape/src/signal/mod.rs
@@ -1,0 +1,183 @@
+use crate::convert_res;
+use core::mem::{size_of, size_of_val, transmute, zeroed};
+use core::ptr::copy_nonoverlapping;
+use errno::{set_errno, Errno};
+use libc::*;
+
+#[no_mangle]
+unsafe extern "C" fn signal(signal: c_int, handler: sighandler_t) -> sighandler_t {
+    libc!(libc::signal(signal, handler));
+
+    use rustix::process::Signal;
+    use rustix::runtime::Sigaction;
+
+    let signal = Signal::from_raw(signal).unwrap();
+    let mut new = zeroed::<Sigaction>();
+    new.sa_handler_kernel = transmute(handler);
+    new.sa_flags = SA_RESTART as _;
+
+    match rustix::runtime::sigaction(signal, Some(new)) {
+        Ok(old) => transmute(old.sa_handler_kernel),
+        Err(_) => SIG_ERR,
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn sigaction(signal: c_int, new: *const sigaction, old: *mut sigaction) -> c_int {
+    libc!(libc::sigaction(signal, new, old));
+
+    use rustix::process::Signal;
+    use rustix::runtime::Sigaction;
+
+    let signal = Signal::from_raw(signal).unwrap();
+    let new = if new.is_null() {
+        None
+    } else {
+        let new = new.read();
+        let mut sa_mask = zeroed();
+        copy_nonoverlapping(
+            &new.sa_mask as *const sigset_t as *const u8,
+            &mut sa_mask as *mut _ as *mut u8,
+            size_of_val(&zeroed::<Sigaction>().sa_mask),
+        );
+
+        let new = Sigaction {
+            sa_handler_kernel: transmute(new.sa_sigaction),
+            sa_flags: new.sa_flags.try_into().unwrap(),
+            sa_restorer: transmute(new.sa_sigaction),
+            sa_mask,
+        };
+
+        Some(new)
+    };
+
+    match convert_res(rustix::runtime::sigaction(signal, new)) {
+        Some(old_action) => {
+            if !old.is_null() {
+                let mut sa_mask = zeroed();
+                copy_nonoverlapping(
+                    &old_action.sa_mask as *const _ as *const u8,
+                    &mut sa_mask as *mut sigset_t as *mut u8,
+                    size_of_val(&zeroed::<Sigaction>().sa_mask),
+                );
+
+                let old_action = sigaction {
+                    sa_sigaction: transmute(old_action.sa_handler_kernel),
+                    sa_flags: old_action.sa_flags.try_into().unwrap(),
+                    sa_restorer: transmute(old_action.sa_restorer),
+                    sa_mask,
+                };
+                old.write(old_action);
+            }
+            0
+        }
+        None => -1,
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn sigaltstack(new: *const stack_t, old: *mut stack_t) -> c_int {
+    libc!(libc::sigaltstack(new, old));
+
+    let new: *const rustix::runtime::Stack = checked_cast!(new);
+    let old: *mut rustix::runtime::Stack = checked_cast!(old);
+
+    let new = if new.is_null() {
+        None
+    } else {
+        Some(new.read())
+    };
+
+    match convert_res(rustix::runtime::sigaltstack(new)) {
+        Some(old_stack) => {
+            if !old.is_null() {
+                old.write(old_stack);
+            }
+            0
+        }
+        None => -1,
+    }
+}
+
+#[cfg(not(target_os = "wasi"))]
+#[no_mangle]
+unsafe extern "C" fn raise(sig: c_int) -> c_int {
+    libc!(libc::raise(sig));
+
+    let sig = rustix::process::Signal::from_raw(sig).unwrap();
+    match convert_res(rustix::runtime::tkill(rustix::thread::gettid(), sig)) {
+        Some(()) => 0,
+        None => -1,
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn abort() {
+    libc!(libc::abort());
+
+    rustix::runtime::tkill(rustix::thread::gettid(), rustix::process::Signal::Abort).ok();
+
+    unimplemented!("`abort()` when `SIGABRT` is ignored")
+}
+
+#[no_mangle]
+unsafe extern "C" fn sigaddset(sigset: *mut sigset_t, signum: c_int) -> c_int {
+    libc!(libc::sigaddset(sigset, signum));
+
+    if signum == 0 || signum as usize - 1 >= size_of::<sigset_t>() * 8 {
+        set_errno(Errno(libc::EINVAL));
+        return -1;
+    }
+
+    let sig_index = (signum - 1) as usize;
+    let mut x = sigset.cast::<usize>().add(sig_index / 8).read();
+    x |= 1_usize << (sig_index % (8 * size_of::<usize>()));
+    sigset.cast::<usize>().add(sig_index / 8).write(x);
+    0
+}
+
+#[no_mangle]
+unsafe extern "C" fn sigdelset(sigset: *mut sigset_t, signum: c_int) -> c_int {
+    libc!(libc::sigdelset(sigset, signum));
+
+    if signum == 0 || signum as usize - 1 >= size_of::<sigset_t>() * 8 {
+        set_errno(Errno(libc::EINVAL));
+        return -1;
+    }
+
+    let sig_index = (signum - 1) as usize;
+    let mut x = sigset.cast::<usize>().add(sig_index / 8).read();
+    x &= !(1_usize << (sig_index % (8 * size_of::<usize>())));
+    sigset.cast::<usize>().add(sig_index / 8).write(x);
+    0
+}
+
+#[no_mangle]
+unsafe extern "C" fn sigemptyset(sigset: *mut sigset_t) -> c_int {
+    libc!(libc::sigemptyset(sigset));
+    sigset.write(zeroed());
+    0
+}
+
+#[no_mangle]
+unsafe extern "C" fn sigfillset(sigset: *mut sigset_t) -> c_int {
+    libc!(libc::sigfillset(sigset));
+    for index in 0..(size_of::<sigset_t>() / size_of::<usize>()) {
+        sigset.cast::<usize>().add(index).write(!0);
+    }
+    0
+}
+
+#[no_mangle]
+unsafe extern "C" fn sigismember(sigset: *const sigset_t, signum: c_int) -> c_int {
+    libc!(libc::sigismember(sigset, signum));
+
+    if signum == 0 || signum as usize - 1 >= size_of::<sigset_t>() * 8 {
+        set_errno(Errno(libc::EINVAL));
+        return -1;
+    }
+
+    let sig_index = (signum - 1) as usize;
+    let x = sigset.cast::<usize>().add(sig_index / 8).read();
+    ((x & (1_usize << (sig_index % (8 * size_of::<usize>())))) != 0) as c_int
+}

--- a/origin/Cargo.toml
+++ b/origin/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/sunfishcode/mustang"
 edition = "2021"
 
 [dependencies]
-linux-raw-sys = { version = "0.3.0", default-features = false, features = ["general", "no_std"] }
-rustix = { version = "0.37.12", default-features = false, features = ["mm", "thread", "time", "runtime", "param", "process"] }
+linux-raw-sys = { version = "0.3.3", default-features = false, features = ["general", "no_std"] }
+rustix = { version = "0.37.13", default-features = false, features = ["mm", "thread", "time", "runtime", "param", "process"] }
 bitflags = "1.3.0"
 memoffset = { version = "0.8.0", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }


### PR DESCRIPTION
This is highly experimental and doesn't actually work for installing actual signal handlers, but it is enough to allow `SIG_IGN` and `SIG_DFL` handlers to work.

Marking as a draft as this depends on unreleased rustix patches.

With this, everything in coreutils except `test_tmp_files_deleted_on_sigint` passes.