### PR TITLE
Implement more functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ Known limitations in `mustang` include:
 
  - No support for dynamic linking yet.
  - Many missing features needed for libraries written in C.
- - Custom signal handlers don't work yet.
 
 ## Background
 

--- a/c-gull/Cargo.toml
+++ b/c-gull/Cargo.toml
@@ -20,7 +20,7 @@ tz-rs = { version = "0.6.11", optional = true }
 printf-compat = { version = "0.1.1", optional = true }
 sync-resolve = { version = "0.3.0", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
-rustix = { version = "0.37.13", default-features = false, optional = true, features = ["fs", "itoa", "net", "param", "process", "rand", "termios", "thread", "time"] }
+rustix = { version = "0.37.14", default-features = false, optional = true, features = ["fs", "itoa", "net", "param", "process", "procfs", "rand", "termios", "thread", "time"] }
 
 [dev-dependencies]
 libc = "0.2.138"

--- a/c-gull/src/sysconf.rs
+++ b/c-gull/src/sysconf.rs
@@ -1,0 +1,50 @@
+use libc::{c_int, c_long, c_ulong};
+
+#[no_mangle]
+unsafe extern "C" fn get_nprocs_conf() -> c_int {
+    //libc!(libc::get_nprocs_conf());
+
+    match std::thread::available_parallelism() {
+        Ok(n) => n.get().try_into().unwrap_or(c_int::MAX),
+        Err(_) => 1,
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn get_nprocs() -> c_int {
+    //libc!(libc::get_nprocs());
+
+    get_nprocs_conf()
+}
+
+#[no_mangle]
+unsafe extern "C" fn get_phys_pages() -> c_long {
+    //libc!(libc::get_phys_pages());
+
+    let info = rustix::process::sysinfo();
+    let mem_unit = if info.mem_unit == 0 {
+        1
+    } else {
+        info.mem_unit as c_ulong
+    };
+
+    (info.totalram * mem_unit / rustix::param::page_size() as c_ulong)
+        .try_into()
+        .unwrap_or(c_long::MAX)
+}
+
+#[no_mangle]
+unsafe extern "C" fn get_avphys_pages() -> c_long {
+    //libc!(libc::get_avphys_pages());
+
+    let info = rustix::process::sysinfo();
+    let mem_unit = if info.mem_unit == 0 {
+        1
+    } else {
+        info.mem_unit as c_ulong
+    };
+
+    ((info.freeram + info.bufferram) * mem_unit / rustix::param::page_size() as c_ulong)
+        .try_into()
+        .unwrap_or(c_long::MAX)
+}

--- a/c-gull/src/termios.rs
+++ b/c-gull/src/termios.rs
@@ -1,0 +1,51 @@
+//! Termios APIs
+//!
+//! TODO: Clean this up. I think I made the wrong call in rustix, and `Termios`
+//! should contain the `termios2` fields. When that's cleaned up, this file can
+//! be significantly cleaned up.
+
+use crate::convert_res;
+use core::cell::SyncUnsafeCell;
+use core::ptr::{copy_nonoverlapping, null_mut};
+use libc::{c_char, c_int, size_t};
+use rustix::fd::BorrowedFd;
+use std::ffi::CString;
+use std::vec::Vec;
+
+#[no_mangle]
+unsafe extern "C" fn ttyname(fd: c_int) -> *mut c_char {
+    libc!(libc::ttyname(fd));
+
+    static STORAGE: SyncUnsafeCell<Option<CString>> = SyncUnsafeCell::new(None);
+
+    let storage = SyncUnsafeCell::get(&STORAGE);
+    let name = match convert_res(rustix::termios::ttyname(
+        BorrowedFd::borrow_raw(fd),
+        Vec::new(),
+    )) {
+        Some(name) => name,
+        None => return null_mut(),
+    };
+    (*storage) = Some(name);
+
+    (*storage).as_ref().unwrap().as_ptr() as *mut c_char
+}
+
+#[no_mangle]
+unsafe extern "C" fn ttyname_r(fd: c_int, buf: *mut c_char, buflen: size_t) -> c_int {
+    libc!(libc::ttyname_r(fd, buf, buflen));
+
+    let name = match rustix::termios::ttyname(BorrowedFd::borrow_raw(fd), Vec::new()) {
+        Ok(name) => name,
+        Err(err) => return err.raw_os_error(),
+    };
+
+    let len = name.as_bytes().len();
+    if len >= buflen {
+        return libc::ERANGE;
+    }
+
+    copy_nonoverlapping(name.as_ptr(), buf, len);
+
+    0
+}

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 libm = "0.2.1"
-rustix = { version = "0.37.13", default-features = false, features = ["fs", "itoa", "net", "param", "process", "rand", "runtime", "termios", "thread", "time"] }
+rustix = { version = "0.37.14", default-features = false, features = ["fs", "itoa", "net", "param", "process", "rand", "runtime", "termios", "thread", "time"] }
 memoffset = "0.8.0"
 realpath-ext = { version = "0.1.0", default-features = false }
 origin = { path = "../origin", default-features = false, version = "^0.8.7" }

--- a/c-scape/src/env/mod.rs
+++ b/c-scape/src/env/mod.rs
@@ -177,6 +177,13 @@ unsafe extern "C" fn unsetenv(key: *const c_char) -> c_int {
     0
 }
 
+#[no_mangle]
+unsafe extern "C" fn getlogin() -> *mut c_char {
+    libc!(libc::getlogin());
+
+    getenv(rustix::cstr!("LOGNAME").as_ptr())
+}
+
 /// GLIBC and origin pass argc, argv, and envp to functions in .init_array, as
 /// a non-standard extension. Use priority 98 so that we run before any
 /// normal user-defined constructor functions and our own functions which

--- a/c-scape/src/fs/mkdir.rs
+++ b/c-scape/src/fs/mkdir.rs
@@ -27,27 +27,3 @@ unsafe extern "C" fn mkdirat(fd: c_int, pathname: *const c_char, mode: libc::mod
         None => -1,
     }
 }
-
-#[no_mangle]
-unsafe extern "C" fn mkfifo(pathname: *const c_char, mode: libc::mode_t) -> c_int {
-    libc!(libc::mkfifo(pathname, mode));
-
-    mkfifoat(libc::AT_FDCWD, pathname, mode)
-}
-
-#[no_mangle]
-unsafe extern "C" fn mkfifoat(fd: c_int, pathname: *const c_char, mode: libc::mode_t) -> c_int {
-    libc!(libc::mkfifoat(fd, pathname, mode));
-
-    let mode = Mode::from_bits((mode & !libc::S_IFMT) as _).unwrap();
-    match convert_res(rustix::fs::mknodat(
-        BorrowedFd::borrow_raw(fd),
-        CStr::from_ptr(pathname.cast()),
-        rustix::fs::FileType::Fifo,
-        mode,
-        0,
-    )) {
-        Some(()) => 0,
-        None => -1,
-    }
-}

--- a/c-scape/src/fs/mknod.rs
+++ b/c-scape/src/fs/mknod.rs
@@ -1,0 +1,61 @@
+use core::ffi::CStr;
+use rustix::fd::BorrowedFd;
+use rustix::fs::{FileType, Mode};
+
+use libc::{c_char, c_int};
+
+use crate::convert_res;
+
+#[no_mangle]
+unsafe extern "C" fn mkfifo(pathname: *const c_char, mode: libc::mode_t) -> c_int {
+    libc!(libc::mkfifo(pathname, mode));
+
+    mkfifoat(libc::AT_FDCWD, pathname, mode)
+}
+
+#[no_mangle]
+unsafe extern "C" fn mkfifoat(fd: c_int, pathname: *const c_char, mode: libc::mode_t) -> c_int {
+    libc!(libc::mkfifoat(fd, pathname, mode));
+
+    mknodat(fd, pathname, mode | libc::S_IFIFO, 0)
+}
+
+#[no_mangle]
+unsafe extern "C" fn mknod(pathname: *const c_char, mode: libc::mode_t, dev: libc::dev_t) -> c_int {
+    libc!(libc::mknod(pathname, mode, dev));
+
+    mknodat(libc::AT_FDCWD, pathname, mode, dev)
+}
+
+#[no_mangle]
+unsafe extern "C" fn mknodat(
+    dirfd: c_int,
+    pathname: *const c_char,
+    mode: libc::mode_t,
+    dev: libc::dev_t,
+) -> c_int {
+    libc!(libc::mknodat(dirfd, pathname, mode, dev));
+
+    let filetype = match mode & libc::S_IFMT {
+        libc::S_IFREG => FileType::RegularFile,
+        libc::S_IFDIR => FileType::Directory,
+        libc::S_IFLNK => FileType::Symlink,
+        libc::S_IFIFO => FileType::Fifo,
+        libc::S_IFSOCK => FileType::Socket,
+        libc::S_IFCHR => FileType::CharacterDevice,
+        libc::S_IFBLK => FileType::BlockDevice,
+        _ => FileType::Unknown,
+    };
+    let mode = Mode::from_bits((mode & !libc::S_IFMT) as _).unwrap();
+
+    match convert_res(rustix::fs::mknodat(
+        BorrowedFd::borrow_raw(dirfd),
+        CStr::from_ptr(pathname.cast()),
+        filetype,
+        mode,
+        dev,
+    )) {
+        Some(()) => 0,
+        None => -1,
+    }
+}

--- a/c-scape/src/fs/mod.rs
+++ b/c-scape/src/fs/mod.rs
@@ -7,6 +7,7 @@ mod inotify;
 mod link;
 mod lseek;
 mod mkdir;
+mod mknod;
 mod open;
 mod readlink;
 mod realpath;

--- a/c-scape/src/fs/xattr.rs
+++ b/c-scape/src/fs/xattr.rs
@@ -1,7 +1,4 @@
 //! Extended attributes.
-//!
-//! These are not yet implemented in rustix. For now, use stubs so that
-//! programs that use them can be linked.
 
 use crate::convert_res;
 use alloc::vec;

--- a/c-scape/src/net/mod.rs
+++ b/c-scape/src/net/mod.rs
@@ -7,8 +7,7 @@ use core::ffi::c_void;
 use core::mem::size_of;
 use core::ptr::copy_nonoverlapping;
 use core::slice;
-use errno::{set_errno, Errno};
-use libc::{c_char, c_int, c_uint};
+use libc::{c_int, c_uint};
 use rustix::fd::{BorrowedFd, IntoRawFd};
 use rustix::net::{
     AcceptFlags, AddressFamily, Ipv4Addr, Ipv6Addr, Protocol, RecvFlags, SendFlags, Shutdown,
@@ -428,23 +427,6 @@ unsafe extern "C" fn setsockopt(
         Some(()) => 0,
         None => -1,
     }
-}
-#[cfg(not(target_os = "wasi"))]
-#[no_mangle]
-unsafe extern "C" fn gethostname(name: *mut c_char, len: usize) -> c_int {
-    let uname = rustix::process::uname();
-    let nodename = uname.nodename();
-    if nodename.to_bytes().len() + 1 > len {
-        set_errno(Errno(libc::ENAMETOOLONG));
-        return -1;
-    }
-    libc::memcpy(
-        name.cast(),
-        nodename.to_bytes().as_ptr().cast(),
-        nodename.to_bytes().len(),
-    );
-    *name.add(nodename.to_bytes().len()) = 0;
-    0
 }
 
 #[no_mangle]

--- a/c-scape/src/process/chroot.rs
+++ b/c-scape/src/process/chroot.rs
@@ -1,0 +1,16 @@
+use core::ffi::CStr;
+
+use libc::{c_char, c_int};
+
+use crate::convert_res;
+
+#[no_mangle]
+unsafe extern "C" fn chroot(path: *const c_char) -> c_int {
+    libc!(libc::chroot(path));
+
+    let path = CStr::from_ptr(path.cast());
+    match convert_res(rustix::process::chroot(path)) {
+        Some(()) => 0,
+        None => -1,
+    }
+}

--- a/c-scape/src/process/groups.rs
+++ b/c-scape/src/process/groups.rs
@@ -1,7 +1,40 @@
+use crate::convert_res;
+use errno::{set_errno, Errno};
+use libc::c_int;
+
 #[no_mangle]
-unsafe extern "C" fn getgroups() {
-    //libc!(libc::getgroups());
-    unimplemented!("getgroups")
+unsafe extern "C" fn getgroups(num: c_int, groups: *mut libc::gid_t) -> c_int {
+    libc!(libc::getgroups(num, groups));
+
+    let returned_groups = match convert_res(rustix::process::getgroups()) {
+        Some(returned_groups) => returned_groups,
+        None => return -1,
+    };
+
+    if num == 0 {
+        return match returned_groups.len().try_into() {
+            Ok(converted) => converted,
+            Err(_) => {
+                set_errno(Errno(libc::ENOMEM));
+                -1
+            }
+        };
+    }
+
+    let mut num_out = 0;
+    let mut groups = groups;
+
+    for group in returned_groups {
+        if num_out == num {
+            set_errno(Errno(libc::EINVAL));
+            return -1;
+        }
+        num_out += 1;
+        groups.write(group.as_raw());
+        groups = groups.add(1);
+    }
+
+    num_out
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/c-scape/src/process/mod.rs
+++ b/c-scape/src/process/mod.rs
@@ -1,4 +1,5 @@
 mod chdir;
+mod chroot;
 mod egid;
 mod euid;
 mod exec;
@@ -7,10 +8,13 @@ mod gid;
 mod groups;
 mod kill;
 mod pid;
+mod priority;
 mod rlimit;
 mod sid;
+mod system;
 mod uid;
 mod umask;
+mod utmp;
 mod wait;
 
 // this entire module is

--- a/c-scape/src/process/pid.rs
+++ b/c-scape/src/process/pid.rs
@@ -22,7 +22,14 @@ unsafe extern "C" fn getppid() -> pid_t {
 #[no_mangle]
 unsafe extern "C" fn setpgid(pid: pid_t, pgid: pid_t) -> c_int {
     libc!(libc::setpgid(pid, pgid));
-    unimplemented!("setpgid")
+
+    match convert_res(rustix::process::setpgid(
+        Pid::from_raw(pid as _),
+        Pid::from_raw(pgid as _),
+    )) {
+        Some(()) => 0,
+        None => -1,
+    }
 }
 
 #[no_mangle]

--- a/c-scape/src/process/priority.rs
+++ b/c-scape/src/process/priority.rs
@@ -1,0 +1,44 @@
+use crate::convert_res;
+use errno::{set_errno, Errno};
+use libc::{c_int, c_uint, id_t};
+use rustix::process::{Pid, Uid};
+
+#[no_mangle]
+unsafe extern "C" fn getpriority(which: c_uint, who: id_t) -> c_int {
+    libc!(libc::getpriority(which, who));
+
+    let result = match which {
+        libc::PRIO_PROCESS => rustix::process::getpriority_process(Pid::from_raw(who)),
+        libc::PRIO_PGRP => rustix::process::getpriority_pgrp(Pid::from_raw(who)),
+        libc::PRIO_USER => rustix::process::getpriority_user(Uid::from_raw(who)),
+        _ => {
+            set_errno(Errno(libc::EINVAL));
+            return -1;
+        }
+    };
+
+    match convert_res(result) {
+        Some(prio) => prio,
+        None => -1,
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn setpriority(which: c_uint, who: id_t, prio: c_int) -> c_int {
+    libc!(libc::setpriority(which, who, prio));
+
+    let result = match which {
+        libc::PRIO_PROCESS => rustix::process::setpriority_process(Pid::from_raw(who), prio),
+        libc::PRIO_PGRP => rustix::process::setpriority_pgrp(Pid::from_raw(who), prio),
+        libc::PRIO_USER => rustix::process::setpriority_user(Uid::from_raw(who), prio),
+        _ => {
+            set_errno(Errno(libc::EINVAL));
+            return -1;
+        }
+    };
+
+    match convert_res(result) {
+        Some(()) => 0,
+        None => -1,
+    }
+}

--- a/c-scape/src/process/system.rs
+++ b/c-scape/src/process/system.rs
@@ -1,0 +1,113 @@
+use crate::convert_res;
+use core::ptr::copy_nonoverlapping;
+use core::slice;
+use errno::{set_errno, Errno};
+use libc::{c_char, c_double, c_int};
+
+#[no_mangle]
+unsafe extern "C" fn uname(buf: *mut libc::utsname) -> c_int {
+    libc!(libc::uname(buf));
+
+    let uname = rustix::process::uname();
+    let buf = &mut *buf;
+
+    let sysname = uname.sysname().to_bytes_with_nul();
+    assert!(sysname.len() <= buf.sysname.len());
+    copy_nonoverlapping(
+        checked_cast!(sysname.as_ptr()),
+        buf.sysname.as_mut_ptr(),
+        sysname.len(),
+    );
+
+    let nodename = uname.nodename().to_bytes_with_nul();
+    assert!(nodename.len() <= buf.nodename.len());
+    copy_nonoverlapping(
+        checked_cast!(nodename.as_ptr()),
+        buf.nodename.as_mut_ptr(),
+        nodename.len(),
+    );
+
+    let release = uname.release().to_bytes_with_nul();
+    assert!(release.len() <= buf.release.len());
+    copy_nonoverlapping(
+        checked_cast!(release.as_ptr()),
+        buf.release.as_mut_ptr(),
+        release.len(),
+    );
+
+    let version = uname.version().to_bytes_with_nul();
+    assert!(version.len() <= buf.version.len());
+    copy_nonoverlapping(
+        checked_cast!(version.as_ptr()),
+        buf.version.as_mut_ptr(),
+        version.len(),
+    );
+
+    let machine = uname.machine().to_bytes_with_nul();
+    assert!(machine.len() <= buf.machine.len());
+    copy_nonoverlapping(
+        checked_cast!(machine.as_ptr()),
+        buf.machine.as_mut_ptr(),
+        machine.len(),
+    );
+
+    let domainname = uname.domainname().to_bytes_with_nul();
+    assert!(domainname.len() <= buf.domainname.len());
+    copy_nonoverlapping(
+        checked_cast!(domainname.as_ptr()),
+        buf.domainname.as_mut_ptr(),
+        domainname.len(),
+    );
+
+    0
+}
+
+#[no_mangle]
+unsafe extern "C" fn getloadavg(a: *mut c_double, n: c_int) -> c_int {
+    libc!(libc::getloadavg(a, n));
+
+    if n == 0 {
+        return 0;
+    }
+    if n < 0 {
+        return -1;
+    }
+
+    let info = rustix::process::sysinfo();
+    let mut a = a;
+
+    for i in 0..core::cmp::min(n as usize, info.loads.len()) {
+        a.write((info.loads[i] as f64) / ((1 << libc::SI_LOAD_SHIFT) as f64));
+        a = a.add(1);
+    }
+
+    n
+}
+
+#[cfg(not(target_os = "wasi"))]
+#[no_mangle]
+unsafe extern "C" fn gethostname(name: *mut c_char, len: usize) -> c_int {
+    let uname = rustix::process::uname();
+    let nodename = uname.nodename();
+    if nodename.to_bytes().len() + 1 > len {
+        set_errno(Errno(libc::ENAMETOOLONG));
+        return -1;
+    }
+    libc::memcpy(
+        name.cast(),
+        nodename.to_bytes().as_ptr().cast(),
+        nodename.to_bytes().len(),
+    );
+    *name.add(nodename.to_bytes().len()) = 0;
+    0
+}
+
+#[cfg(not(target_os = "wasi"))]
+#[no_mangle]
+unsafe extern "C" fn sethostname(name: *mut c_char, len: usize) -> c_int {
+    let slice = slice::from_raw_parts(name.cast(), len);
+    match convert_res(rustix::process::sethostname(slice)) {
+        Some(()) => 0,
+        None => -1,
+    }
+}

--- a/c-scape/src/process/uid.rs
+++ b/c-scape/src/process/uid.rs
@@ -1,4 +1,4 @@
-use libc::uid_t;
+use libc::{c_int, uid_t};
 
 #[no_mangle]
 unsafe extern "C" fn getuid() -> uid_t {
@@ -7,7 +7,11 @@ unsafe extern "C" fn getuid() -> uid_t {
 }
 
 #[no_mangle]
-unsafe extern "C" fn setuid() {
-    //libc!(libc::setuid());
+unsafe extern "C" fn setuid(uid: uid_t) -> c_int {
+    libc!(libc::setuid(uid));
+
+    // rustix has a `setuid` function, but it just wraps the Linux syscall
+    // which sets a per-thread UID rather than the whole process UID. Linux
+    // expects libc's to have logic to set the UID for all the threads.
     unimplemented!("setuid")
 }

--- a/c-scape/src/process/utmp.rs
+++ b/c-scape/src/process/utmp.rs
@@ -1,0 +1,43 @@
+use core::ptr::null_mut;
+
+#[no_mangle]
+unsafe extern "C" fn getutxent() -> *mut libc::utmpx {
+    libc!(libc::getutxent());
+    null_mut() // unimplemented
+}
+
+#[no_mangle]
+unsafe extern "C" fn getutxid(_ut: *const libc::utmpx) -> *mut libc::utmpx {
+    libc!(libc::getutxid(_ut));
+    null_mut() // unimplemented
+}
+
+#[no_mangle]
+unsafe extern "C" fn getutxline(_ut: *const libc::utmpx) -> *mut libc::utmpx {
+    libc!(libc::getutxline(_ut));
+    null_mut() // unimplemented
+}
+
+#[no_mangle]
+unsafe extern "C" fn pututxline(_ut: *const libc::utmpx) -> *mut libc::utmpx {
+    libc!(libc::pututxline(_ut));
+    null_mut() // unimplemented
+}
+
+#[no_mangle]
+unsafe extern "C" fn setutxent() {
+    libc!(libc::setutxent());
+    // unimplemented
+}
+
+#[no_mangle]
+unsafe extern "C" fn endutxent() {
+    libc!(libc::endutxent());
+    // unimplemented
+}
+
+#[no_mangle]
+unsafe extern "C" fn utmpxname(_file: *const libc::c_char) -> libc::c_int {
+    libc!(libc::utmpxname(_file));
+    0 // unimplemented
+}

--- a/origin/Cargo.toml
+++ b/origin/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/sunfishcode/mustang"
 edition = "2021"
 
 [dependencies]
-linux-raw-sys = { version = "0.3.3", default-features = false, features = ["general", "no_std"] }
-rustix = { version = "0.37.13", default-features = false, features = ["mm", "thread", "time", "runtime", "param", "process"] }
+linux-raw-sys = { version = "0.3.4", default-features = false, features = ["general", "no_std"] }
+rustix = { version = "0.37.14", default-features = false, features = ["mm", "thread", "time", "runtime", "param", "process"] }
 bitflags = "1.3.0"
 memoffset = { version = "0.8.0", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }

--- a/origin/src/arch-aarch64.rs
+++ b/origin/src/arch-aarch64.rs
@@ -2,7 +2,7 @@ use alloc::boxed::Box;
 use core::any::Any;
 use core::arch::asm;
 use core::ffi::c_void;
-use linux_raw_sys::general::{__NR_clone, __NR_exit, __NR_munmap};
+use linux_raw_sys::general::{__NR_clone, __NR_exit, __NR_munmap, __NR_rt_sigreturn};
 use rustix::process::RawPid;
 
 /// A wrapper around the Linux `clone` system call.
@@ -80,3 +80,20 @@ pub(super) unsafe fn munmap_and_exit_thread(map_addr: *mut c_void, map_len: usiz
         options(noreturn, nostack)
     );
 }
+
+/// Invoke the `__NR_rt_sigreturn` system call to return control from a signal
+/// handler.
+#[naked]
+pub(super) unsafe extern "C" fn return_from_signal_handler() {
+    asm!(
+        "mov x8,{__NR_rt_sigreturn}",
+        "svc 0",
+        "udf #16",
+        __NR_rt_sigreturn = const __NR_rt_sigreturn,
+        options(noreturn)
+    );
+}
+
+/// Invoke the appropriate system call to return control from a signal
+/// handler that does not use `SA_SIGINFO`.
+pub(super) use return_from_signal_handler as return_from_signal_handler_noinfo;

--- a/origin/src/lib.rs
+++ b/origin/src/lib.rs
@@ -14,6 +14,8 @@ extern crate alloc;
 pub mod sync;
 
 mod program;
+#[cfg(target_vendor = "mustang")]
+mod signal;
 #[cfg(feature = "threads")]
 #[cfg_attr(not(target_vendor = "mustang"), path = "threads_via_pthreads.rs")]
 mod threads;
@@ -28,6 +30,8 @@ mod threads;
 mod arch;
 
 pub use program::{at_exit, exit, exit_immediately};
+#[cfg(target_vendor = "mustang")]
+pub use signal::{sigaction, Sigaction};
 #[cfg(feature = "threads")]
 #[cfg(feature = "set_thread_id")]
 pub use threads::set_current_thread_id_after_a_fork;

--- a/origin/src/signal.rs
+++ b/origin/src/signal.rs
@@ -1,0 +1,34 @@
+use rustix::io;
+use rustix::process::Signal;
+#[cfg(not(target_arch = "riscv64"))]
+use {
+    crate::arch,
+    linux_raw_sys::ctypes::c_ulong,
+    linux_raw_sys::general::{SA_RESTORER, SA_SIGINFO},
+};
+
+/// A signal action record for use with [`sigaction`].
+pub type Sigaction = linux_raw_sys::general::kernel_sigaction;
+
+/// Register a signal handler.
+///
+/// # Safety
+///
+/// yolo
+pub unsafe fn sigaction(sig: Signal, action: Option<Sigaction>) -> io::Result<Sigaction> {
+    #[allow(unused_mut)]
+    let mut action = action;
+
+    #[cfg(not(target_arch = "riscv64"))]
+    if let Some(action) = &mut action {
+        action.sa_flags |= SA_RESTORER as c_ulong;
+
+        if (action.sa_flags & SA_SIGINFO as c_ulong) == SA_SIGINFO as c_ulong {
+            action.sa_restorer = Some(arch::return_from_signal_handler);
+        } else {
+            action.sa_restorer = Some(arch::return_from_signal_handler_noinfo);
+        }
+    }
+
+    rustix::runtime::sigaction(sig, action)
+}

--- a/tests/process-common.rs
+++ b/tests/process-common.rs
@@ -1,0 +1,222 @@
+//! The following is derived from Rust's
+//! library/std/src/sys/unix/process/process_common/tests.rs at revision
+//! a52c79e859142c1cd5c0c5bdb73f16b754e1b98f.
+
+mustang::can_run_this!();
+
+use std::ffi::OsStr;
+use std::io::{Read, Write};
+use std::mem;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+use std::process::{Command, Stdio};
+use std::ptr;
+
+#[doc(hidden)]
+pub trait IsMinusOne {
+    fn is_minus_one(&self) -> bool;
+}
+
+macro_rules! impl_is_minus_one {
+    ($($t:ident)*) => ($(impl IsMinusOne for $t {
+        fn is_minus_one(&self) -> bool {
+            *self == -1
+        }
+    })*)
+}
+
+impl_is_minus_one! { i8 i16 i32 i64 isize }
+
+pub fn cvt<T: IsMinusOne>(t: T) -> std::io::Result<T> {
+    if t.is_minus_one() {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(t)
+    }
+}
+
+pub fn cvt_r<T, F>(mut f: F) -> std::io::Result<T>
+where
+    T: IsMinusOne,
+    F: FnMut() -> T,
+{
+    loop {
+        match cvt(f()) {
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+            other => return other,
+        }
+    }
+}
+
+#[allow(dead_code)] // Not used on all platforms.
+pub fn cvt_nz(error: libc::c_int) -> std::io::Result<()> {
+    if error == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::from_raw_os_error(error))
+    }
+}
+
+macro_rules! t {
+    ($e:expr) => {
+        match $e {
+            Ok(t) => t,
+            Err(e) => panic!("received error for `{}`: {}", stringify!($e), e),
+        }
+    };
+}
+
+#[test]
+#[cfg_attr(
+    any(
+        // See #14232 for more information, but it appears that signal delivery to a
+        // newly spawned process may just be raced in the macOS, so to prevent this
+        // test from being flaky we ignore it on macOS.
+        target_os = "macos",
+        // When run under our current QEMU emulation test suite this test fails,
+        // although the reason isn't very clear as to why. For now this test is
+        // ignored there.
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+    ),
+    ignore
+)]
+fn test_process_mask() {
+    // Test to make sure that a signal mask *does* get inherited.
+    fn test_inner(mut cmd: Command) {
+        unsafe {
+            let mut set = mem::MaybeUninit::<libc::sigset_t>::uninit();
+            let mut old_set = mem::MaybeUninit::<libc::sigset_t>::uninit();
+            t!(cvt(libc::sigemptyset(set.as_mut_ptr())));
+            t!(cvt(libc::sigaddset(set.as_mut_ptr(), libc::SIGINT)));
+            t!(cvt_nz(libc::pthread_sigmask(
+                libc::SIG_SETMASK,
+                set.as_ptr(),
+                old_set.as_mut_ptr()
+            )));
+
+            cmd.stdin(Stdio::piped());
+            cmd.stdout(Stdio::piped());
+            cmd.stderr(Stdio::null());
+
+            let mut child = t!(cmd.spawn());
+            let mut stdin_write = child.stdin.take().unwrap();
+            let mut stdout_read = child.stdout.take().unwrap();
+
+            t!(cvt_nz(libc::pthread_sigmask(
+                libc::SIG_SETMASK,
+                old_set.as_ptr(),
+                ptr::null_mut()
+            )));
+
+            t!(cvt(libc::kill(child.id() as libc::pid_t, libc::SIGINT)));
+            // We need to wait until SIGINT is definitely delivered. The
+            // easiest way is to write something to cat, and try to read it
+            // back: if SIGINT is unmasked, it'll get delivered when cat is
+            // next scheduled.
+            let _ = stdin_write.write(b"Hello");
+            drop(stdin_write);
+
+            // Exactly 5 bytes should be read.
+            let mut buf = [0; 5];
+            let ret = t!(stdout_read.read(&mut buf));
+            assert_eq!(ret, 5);
+            assert_eq!(&buf, b"Hello");
+
+            t!(child.wait());
+        }
+    }
+
+    // A plain `Command::new` uses the posix_spawn path on many platforms.
+    let cmd = Command::new(OsStr::new("cat"));
+    test_inner(cmd);
+
+    // Specifying `pre_exec` forces the fork/exec path.
+    let mut cmd = Command::new(OsStr::new("cat"));
+    unsafe { cmd.pre_exec(Box::new(|| Ok(()))) };
+    test_inner(cmd);
+}
+
+#[test]
+#[cfg_attr(
+    any(
+        // See test_process_mask
+        target_os = "macos",
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+    ),
+    ignore
+)]
+fn test_process_group_posix_spawn() {
+    unsafe {
+        // Spawn a cat subprocess that's just going to hang since there is no I/O.
+        let mut cmd = Command::new(OsStr::new("cat"));
+        cmd.process_group(0);
+        cmd.stdin(Stdio::piped());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::null());
+        let mut child = t!(cmd.spawn());
+
+        // Check that we can kill its process group, which means there *is* one.
+        t!(cvt(libc::kill(-(child.id() as libc::pid_t), libc::SIGINT)));
+
+        t!(child.wait());
+    }
+}
+
+#[test]
+#[cfg_attr(
+    any(
+        // See test_process_mask
+        target_os = "macos",
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+    ),
+    ignore
+)]
+fn test_process_group_no_posix_spawn() {
+    unsafe {
+        // Same as above, create hang-y cat. This time, force using the non-posix_spawnp path.
+        let mut cmd = Command::new(OsStr::new("cat"));
+        cmd.process_group(0);
+        cmd.pre_exec(Box::new(|| Ok(()))); // pre_exec forces fork + exec
+        cmd.stdin(Stdio::piped());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::null());
+        let mut child = t!(cmd.spawn());
+
+        // Check that we can kill its process group, which means there *is* one.
+        t!(cvt(libc::kill(-(child.id() as libc::pid_t), libc::SIGINT)));
+
+        t!(child.wait());
+    }
+}
+
+/*
+#[test]
+fn test_program_kind() {
+    let vectors = &[
+        ("foo", ProgramKind::PathLookup),
+        ("foo.out", ProgramKind::PathLookup),
+        ("./foo", ProgramKind::Relative),
+        ("../foo", ProgramKind::Relative),
+        ("dir/foo", ProgramKind::Relative),
+        // Note that paths on Unix can't contain / in them, so this is actually the directory "fo\\"
+        // followed by the file "o".
+        ("fo\\/o", ProgramKind::Relative),
+        ("/foo", ProgramKind::Absolute),
+        ("/dir/../foo", ProgramKind::Absolute),
+    ];
+
+    for (program, expected_kind) in vectors {
+        assert_eq!(
+            ProgramKind::new(program.as_ref()),
+            *expected_kind,
+            "actual != expected program kind for input {program}",
+        );
+    }
+}
+*/


### PR DESCRIPTION
 - Add a sigreturn mechanism to origin, and use it to implement custom signal handlers.
 - Add the Rust process_common/tests.rs test, which now passes.
 - Implement several new functions.
 - Add stub implementations of the utmp functions for now.

Fixes #87.
Fixes #198.
Fixes #199.