### PR TITLE
Fix `execvp` on shell scripts.

### DIFF
--- a/c-gull/src/printf.rs
+++ b/c-gull/src/printf.rs
@@ -186,6 +186,21 @@ unsafe extern "C" fn __memcpy_chk(
     libc::memcpy(dest, src, len)
 }
 
+// <https://refspecs.linuxbase.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/libc---strncpy-chk-1.html>
+#[no_mangle]
+unsafe extern "C" fn __strncpy_chk(
+    dest: *mut c_char,
+    src: *const c_char,
+    len: size_t,
+    destlen: size_t,
+) -> *mut c_char {
+    if destlen < len {
+        __chk_fail();
+    }
+
+    libc::strncpy(dest, src, len)
+}
+
 #[no_mangle]
 unsafe extern "C" fn perror(user_message: *const c_char) {
     libc!(libc::perror(user_message));

--- a/c-scape/src/time/mod.rs
+++ b/c-scape/src/time/mod.rs
@@ -119,3 +119,10 @@ unsafe extern "C" fn clock_settime(id: c_int, tp: *mut libc::timespec) -> c_int 
         None => -1,
     }
 }
+
+#[no_mangle]
+unsafe extern "C" fn difftime(time1: libc::time_t, time0: libc::time_t) -> f64 {
+    libc!(libc::difftime(time1, time0));
+
+    (time1 as i128 - time0 as i128) as f64
+}

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -46,10 +46,8 @@ fn smoke() {
     assert!(p.wait().unwrap().success());
 }
 
-// NOTE(mustang): fails in the CI for a reason unreleated to mustang
-// see https://github.com/rust-lang/rust/issues/90825 for details
 #[test]
-#[cfg_attr(any(target_os = "android", not(target_vendor = "mustang")), ignore)]
+#[cfg_attr(target_os = "android", ignore)]
 fn smoke_failure() {
     match Command::new("if-this-is-a-binary-then-the-world-has-ended").spawn() {
         Ok(..) => panic!(),
@@ -203,10 +201,7 @@ fn test_process_status() {
     assert!(status.success());
 }
 
-// NOTE(mustang): fails in the CI for a reason unreleated to mustang
-// see https://github.com/rust-lang/rust/issues/90825 for details
 #[test]
-#[cfg_attr(not(target_vendor = "mustang"), ignore)]
 fn test_process_output_fail_to_start() {
     match Command::new("/no-binary-by-this-name-should-exist").output() {
         Err(e) => assert_eq!(e.kind(), ErrorKind::NotFound),


### PR DESCRIPTION
On Linux at least, `execveat` with a directory fd opened with `O_CLOEXEC` can't run programs that use `#!` such as shell scripts. So switch `execvp` back to allocating a buffer, using an `mmap` syscall so that it's safe to do in the child of a fork, and using plain `execve`.

Also, implement `difftime` and `__strncmp_chk`.