### PR TITLE
Use cargo features rather than `target_vendor` in c-scape and c-gull

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ publish = false
 
 [dev-dependencies]
 mustang = { path = "mustang", version = "^0.10.0" }
-c-scape = { path = "c-scape", version = "^0.10.0" }
-c-gull = { path = "c-gull", version = "^0.10.0" }
 similar-asserts = "1.1.0"
 rand = "0.8.4"
 libc = "0.2.138"
@@ -31,6 +29,11 @@ which = "4.4.0"
 # Test that the core_simd crate works under mustang.
 # TODO: Re-enable this when core_simd works on Rust nightly.
 #core_simd = { git = "https://github.com/rust-lang/portable-simd" }
+
+[target.'cfg(target_vendor = "mustang")'.dependencies]
+c-gull = { path = "c-gull", version = "^0.10.0", features = ["take-charge"] }
+[target.'cfg(not(target_vendor = "mustang"))'.dependencies]
+c-gull = { path = "c-gull", version = "^0.10.0", features = ["coexist-with-libc"] }
 
 [features]
 default = ["threads"]

--- a/c-gull/Cargo.toml
+++ b/c-gull/Cargo.toml
@@ -29,3 +29,12 @@ libc = "0.2.138"
 default = ["threads", "std"]
 threads = ["c-scape/threads"]
 std = ["c-scape/std", "rustix", "log", "printf-compat", "tz-rs", "errno", "sync-resolve"]
+
+# One of the following two features must be enabled:
+
+# Enable this to tell c-gull to take control of the process.
+take-charge = ["c-scape/take-charge"]
+
+# Enable this to tell c-gull to let a libc be in control of
+# the process.
+coexist-with-libc = ["c-scape/coexist-with-libc"]

--- a/c-gull/README.md
+++ b/c-gull/README.md
@@ -35,14 +35,20 @@ optimized.
 This is part of the [Mustang] project, building Rust programs written entirely
 in Rust.
 
-## Using c-gull in non-mustang programs
+## c-gull's two modes
 
-c-gull can also be used as a drop-in (partial) libc replacement in non-mustang
-builds, provided you're using nightly Rust. To use it, just change your typical
-libc dependency in Cargo.toml to this:
+c-gull has two main cargo features: "take-charge" and "coexist-with-libc". One
+of these must be enabled.
+
+In "take-charge" mode, c-gull takes charge of the process, handling program
+startup (via origin) providing `malloc` (via c-scape), and other things.
+
+In "coexist-witht-libc" mode, c-gull can be used as a drop-in (partial) libc
+replacement in non-mustang builds, provided you're using nightly Rust. To use
+it, just change your typical libc dependency in Cargo.toml to this:
 
 ```toml
-libc = { version = "<c-gull version>", package = "c-gull" }
+libc = { version = "<c-gull version>", package = "c-gull", features = ["coexist-with-libc"] }
 ```
 
 and c-gull will replace as many of the system libc implementation with its own

--- a/c-gull/src/use_libc.rs
+++ b/c-gull/src/use_libc.rs
@@ -55,7 +55,7 @@ macro_rules! libc {
 
 /// This is used to check that our type definition matches the layout of the
 /// corresponding libc type.
-#[cfg(all(target_vendor = "mustang", feature = "threads"))]
+#[cfg(all(feature = "take-charge", feature = "threads"))]
 macro_rules! libc_type {
     ($name:ident, $libc:ident) => {
         #[cfg(test)]

--- a/c-scape/Cargo.toml
+++ b/c-scape/Cargo.toml
@@ -26,12 +26,6 @@ rand_pcg = "0.3.1"
 rand_core = "0.6.4"
 rand = { version = "0.8.5", default-features = false }
 
-[target.'cfg(target_vendor = "mustang")'.dependencies]
-origin = { version = "0.13.0", default-features = false, features = ["origin-start", "origin-thread", "origin-signal", "origin-program"] }
-
-[target.'cfg(not(target_vendor = "mustang"))'.dependencies]
-origin = { version = "0.13.0", default-features = false, features = ["libc"] }
-
 [dev-dependencies]
 libc = "0.2.138"
 static_assertions = "1.1.0"
@@ -42,3 +36,12 @@ once_cell = "1.8.0"
 default = ["threads", "std"]
 threads = ["origin/set_thread_id"]
 std = ["rustix/std"]
+
+# One of the following two features must be enabled:
+
+# Enable this to tell c-scape to take control of the process.
+take-charge = ["origin/origin-start", "origin/origin-thread", "origin/origin-signal", "origin/origin-program"]
+
+# Enable this to tell c-scape to let a libc be in control of
+# the process.
+coexist-with-libc = ["origin/libc"]

--- a/c-scape/README.md
+++ b/c-scape/README.md
@@ -17,4 +17,6 @@ c-scape is a layer underneath [c-gull]. It provides a subset of libc features,
 containing only features that don't require Rust's `std` to implement. This
 allows it to be used by `std` itself.
 
+Similar to c-gull, c-scape has "take-charge" and "coexist-with-libc" modes.
+
 [c-gull]: https://crates.io/crates/c-gull

--- a/c-scape/src/at_fork.rs
+++ b/c-scape/src/at_fork.rs
@@ -50,7 +50,7 @@ pub(crate) fn at_fork(
 /// # Safety
 ///
 /// Wildly unsafe. See the documentation comment for [`rustix::runtime::fork`].
-/// On top off that, this calls the unsafe functions registered with
+/// On top of that, this calls the unsafe functions registered with
 /// [`at_fork`].
 pub(crate) unsafe fn fork() -> rustix::io::Result<Option<rustix::process::Pid>> {
     let funcs = FORK_FUNCS.lock();

--- a/c-scape/src/env/mod.rs
+++ b/c-scape/src/env/mod.rs
@@ -188,7 +188,7 @@ unsafe extern "C" fn getlogin() -> *mut c_char {
 /// a non-standard extension. Use priority 98 so that we run before any
 /// normal user-defined constructor functions and our own functions which
 /// depend on `getenv` working.
-#[cfg(any(target_env = "gnu", target_vendor = "mustang"))]
+#[cfg(any(target_env = "gnu", feature = "take-charge"))]
 #[link_section = ".init_array.00098"]
 #[used]
 static INIT_ARRAY: unsafe extern "C" fn(c_int, *mut *mut c_char, *mut *mut c_char) = {
@@ -198,7 +198,7 @@ static INIT_ARRAY: unsafe extern "C" fn(c_int, *mut *mut c_char, *mut *mut c_cha
     function
 };
 
-#[cfg(not(any(target_env = "gnu", target_vendor = "mustang")))]
+#[cfg(not(any(target_env = "gnu", feature = "take-charge")))]
 static INIT_ARRAY: Unimplemented = Unimplemented::new();
 
 #[cfg(not(target_os = "wasi"))]

--- a/c-scape/src/fs/dir/readdir.rs
+++ b/c-scape/src/fs/dir/readdir.rs
@@ -16,8 +16,8 @@ unsafe extern "C" fn readdir64_r(
 ) -> c_int {
     libc!(libc::readdir64_r(dir.cast(), entry, ptr));
 
-    let mustang_dir = dir.cast::<CScapeDir>();
-    let dir = &mut (*mustang_dir).dir;
+    let c_scape_dir = dir.cast::<CScapeDir>();
+    let dir = &mut (*c_scape_dir).dir;
     match dir.read() {
         None => {
             *ptr = null_mut();
@@ -56,8 +56,8 @@ unsafe extern "C" fn readdir64_r(
 unsafe extern "C" fn readdir64(dir: *mut libc::DIR) -> *mut libc::dirent64 {
     libc!(libc::readdir64(dir.cast()));
 
-    let mustang_dir = dir.cast::<CScapeDir>();
-    let dir = &mut (*mustang_dir).dir;
+    let c_scape_dir = dir.cast::<CScapeDir>();
+    let dir = &mut (*c_scape_dir).dir;
     match dir.read() {
         None => null_mut(),
         Some(Ok(e)) => {
@@ -71,7 +71,7 @@ unsafe extern "C" fn readdir64(dir: *mut libc::DIR) -> *mut libc::dirent64 {
                 rustix::fs::FileType::BlockDevice => libc::DT_BLK,
                 rustix::fs::FileType::Unknown => libc::DT_UNKNOWN,
             };
-            (*mustang_dir).storage.dirent64 = libc::dirent64 {
+            (*c_scape_dir).storage.dirent64 = libc::dirent64 {
                 d_ino: e.ino(),
                 d_off: 0, // We don't implement `seekdir` yet anyway.
                 d_reclen: (offset_of!(libc::dirent64, d_name) + e.file_name().to_bytes().len() + 1)
@@ -81,9 +81,9 @@ unsafe extern "C" fn readdir64(dir: *mut libc::DIR) -> *mut libc::dirent64 {
                 d_name: [0; 256],
             };
             let len = core::cmp::min(256, e.file_name().to_bytes().len());
-            (*mustang_dir).storage.dirent64.d_name[..len]
+            (*c_scape_dir).storage.dirent64.d_name[..len]
                 .copy_from_slice(transmute(e.file_name().to_bytes()));
-            &mut (*mustang_dir).storage.dirent64
+            &mut (*c_scape_dir).storage.dirent64
         }
         Some(Err(err)) => {
             set_errno(Errno(err.raw_os_error()));
@@ -96,8 +96,8 @@ unsafe extern "C" fn readdir64(dir: *mut libc::DIR) -> *mut libc::dirent64 {
 unsafe extern "C" fn readdir(dir: *mut libc::DIR) -> *mut libc::dirent {
     libc!(libc::readdir(dir.cast()));
 
-    let mustang_dir = dir.cast::<CScapeDir>();
-    let dir = &mut (*mustang_dir).dir;
+    let c_scape_dir = dir.cast::<CScapeDir>();
+    let dir = &mut (*c_scape_dir).dir;
     match dir.read() {
         None => null_mut(),
         Some(Ok(e)) => {
@@ -113,7 +113,7 @@ unsafe extern "C" fn readdir(dir: *mut libc::DIR) -> *mut libc::dirent {
             };
 
             let result: Result<(), core::num::TryFromIntError> = try {
-                (*mustang_dir).storage.dirent = libc::dirent {
+                (*c_scape_dir).storage.dirent = libc::dirent {
                     d_ino: e.ino().try_into()?,
                     d_off: 0, // We don't implement `seekdir` yet anyway.
                     d_reclen: (offset_of!(libc::dirent64, d_name)
@@ -135,9 +135,9 @@ unsafe extern "C" fn readdir(dir: *mut libc::DIR) -> *mut libc::dirent {
             }
 
             let len = core::cmp::min(256, e.file_name().to_bytes().len());
-            (*mustang_dir).storage.dirent.d_name[..len]
+            (*c_scape_dir).storage.dirent.d_name[..len]
                 .copy_from_slice(transmute(e.file_name().to_bytes()));
-            &mut (*mustang_dir).storage.dirent
+            &mut (*c_scape_dir).storage.dirent
         }
         Some(Err(err)) => {
             set_errno(Errno(err.raw_os_error()));

--- a/c-scape/src/lib.rs
+++ b/c-scape/src/lib.rs
@@ -11,6 +11,12 @@
 #![deny(lossy_provenance_casts)]
 #![feature(try_blocks)]
 
+// Check that our features were used as we intend.
+#[cfg(all(feature = "coexist-with-libc", feature = "take-charge"))]
+compile_error!("Enable only one of \"coexist-with-libc\" and \"take-charge\".");
+#[cfg(all(not(feature = "coexist-with-libc"), not(feature = "take-charge")))]
+compile_error!("Enable one \"coexist-with-libc\" and \"take-charge\".");
+
 extern crate alloc;
 extern crate compiler_builtins;
 
@@ -44,7 +50,7 @@ mod env;
 mod fs;
 mod io;
 
-#[cfg(target_vendor = "mustang")]
+#[cfg(feature = "take-charge")]
 mod malloc;
 
 mod math;
@@ -61,12 +67,12 @@ mod process;
 mod rand;
 mod rand48;
 #[cfg(not(target_os = "wasi"))]
-#[cfg(target_vendor = "mustang")]
+#[cfg(feature = "take-charge")]
 mod signal;
 mod termios_;
 
 #[cfg(feature = "threads")]
-#[cfg(target_vendor = "mustang")]
+#[cfg(feature = "take-charge")]
 mod threads;
 
 mod errno_;
@@ -82,7 +88,7 @@ mod syscall;
 mod time;
 
 /// An ABI-conforming `__dso_handle`.
-#[cfg(target_vendor = "mustang")]
+#[cfg(feature = "take-charge")]
 #[no_mangle]
 static __dso_handle: UnsafeSendSyncVoidStar =
     UnsafeSendSyncVoidStar(&__dso_handle as *const _ as *const _);
@@ -97,8 +103,11 @@ static __dso_handle: UnsafeSendSyncVoidStar =
 /// correspond to `*mut c_void`, however we can assume the pointee is never
 /// actually mutated.
 #[repr(transparent)]
+#[cfg(feature = "take-charge")]
 struct UnsafeSendSyncVoidStar(*const core::ffi::c_void);
+#[cfg(feature = "take-charge")]
 unsafe impl Send for UnsafeSendSyncVoidStar {}
+#[cfg(feature = "take-charge")]
 unsafe impl Sync for UnsafeSendSyncVoidStar {}
 
 /// Adapt from origin's `origin_main` to a C ABI `main`.

--- a/c-scape/src/process_.rs
+++ b/c-scape/src/process_.rs
@@ -1,10 +1,10 @@
 use crate::convert_res;
 use core::ffi::CStr;
 use core::mem::{size_of, zeroed};
-#[cfg(target_vendor = "mustang")]
+#[cfg(feature = "take-charge")]
 use core::ptr;
 use core::ptr::null_mut;
-#[cfg(target_vendor = "mustang")]
+#[cfg(feature = "take-charge")]
 use libc::c_ulong;
 use libc::{c_char, c_int, c_long, c_void};
 
@@ -48,20 +48,20 @@ unsafe extern "C" fn sysconf(name: c_int) -> c_long {
 // `getauxval` usually returns `unsigned long`, but we make it a pointer type
 // so that it preserves provenance.
 //
-// This is not used in non-mustang configurations because libc startup code
-// sometimes needs to call `getauxval` before rustix is initialized.
-#[cfg(target_vendor = "mustang")]
+// This is not used in coexist-with-libc configurations because libc startup
+// code sometimes needs to call `getauxval` before rustix is initialized.
+#[cfg(feature = "take-charge")]
 #[no_mangle]
 unsafe extern "C" fn getauxval(type_: c_ulong) -> *mut c_void {
     libc!(ptr::from_exposed_addr_mut(libc::getauxval(type_) as _));
     unimplemented!("unrecognized getauxval {}", type_)
 }
 
-// As with `getauxval`, this is not used in non-mustang configurations because
-// libc startup code sometimes needs to call `getauxval` before rustix is
-// initialized.
+// As with `getauxval`, this is not used in coexist-with-libc configurations
+// because libc startup code sometimes needs to call `getauxval` before rustix
+// is initialized.
 #[cfg(target_arch = "aarch64")]
-#[cfg(target_vendor = "mustang")]
+#[cfg(feature = "take-charge")]
 #[no_mangle]
 unsafe extern "C" fn __getauxval(type_: c_ulong) -> *mut c_void {
     //libc!(ptr::from_exposed_addr(libc::__getauxval(type_) as _));

--- a/c-scape/src/use_libc.rs
+++ b/c-scape/src/use_libc.rs
@@ -55,7 +55,7 @@ macro_rules! libc {
 
 /// This is used to check that our type definition matches the layout of the
 /// corresponding libc type.
-#[cfg(all(target_vendor = "mustang", feature = "threads"))]
+#[cfg(all(feature = "take-charge", feature = "threads"))]
 macro_rules! libc_type {
     ($name:ident, $libc:ident) => {
         #[cfg(test)]

--- a/mustang/Cargo.toml
+++ b/mustang/Cargo.toml
@@ -33,7 +33,7 @@ features = [
 
 [target.'cfg(target_vendor = "mustang")'.dependencies]
 origin = { version = "0.13.0", default-features = false }
-c-gull = { path = "../c-gull", version = "^0.10.0", default-features = false }
+c-gull = { path = "../c-gull", version = "^0.10.0", default-features = false, features = ["take-charge"] }
 
 # A general-purpose `global_allocator` implementation.
 rustix-dlmalloc = { version = "0.1.0", features = ["global"], optional = true }

--- a/test-crates/libc-replacement/Cargo.toml
+++ b/test-crates/libc-replacement/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 #libc = "0.2"
 
 # But in this example, we use c-gull instead of libc:
-libc = { path = "../../c-gull", package = "c-gull" }
+libc = { path = "../../c-gull", features = ["coexist-with-libc"], package = "c-gull" }
 
 # This is just an example crate, and not part of the mustang workspace.
 [workspace]


### PR DESCRIPTION
Add cargo features "take-charge" and "coexist-with-libc" to c-scape and c-gull, and use those features instead of testing for `target_vendor = "mustang"`.

This is similar to how origin was recently converted to use cargo features instead of `target_vendor = "mustang"` and will enable c-scape and c-gull to be used in more ways.