### PR TITLE
Add a mention of the new Eyra project to Mustang's README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,22 @@ Known limitations in `mustang` include:
 ## Alternatives
 
 [Eyra] uses the same underlying libraries as Mustang, but doesn't use a custom
-target, and doesn't need `-Z build-std`. And, it supports LTO.
+target, and doesn't need `-Z build-std`.
+
+Using [Origin] directly is another option; there are [examples] showing how
+to do this. Using origin directly can produce very small binary sizes; the
+`tiny` example can produce a 408-byte executable. Among other things, Origin
+by itself works with LTO. The big downside of using Origin directly is that
+it doesn't provide a `std` implementation.
+
+[Origin Studio] is a demo of what a `std`-like environment on top of Origin
+might look like. It has things like `println!`, but it's also currently lots
+of features, such as `File`.
 
 [Eyra]: https://github.com/sunfishcode/c-ward/tree/main/eyra
+[Origin]: https://github.com/sunfishcode/origin
+[examples]: https://github.com/sunfishcode/origin/tree/main/example-crates
+[Origin Studio]: https://github.com/sunfishcode/origin-studio
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ That's a Rust program built entirely from Rust saying "Hello, world!"!
 For more detail, mustang has an `env_logger` feature, which you can enable, and set
 `RUST_LOG` to see various pieces of mustang in action:
 ```
-$ RUST_LOG=trace cargo +nightly run --quiet -Z build-std --target=x86_64-mustang-linux-gnu --example hello --features env_logger
+$ RUST_LOG=trace cargo +nightly run --quiet -Z build-std --target=x86_64-mustang-linux-gnu --example hello --features log,env_logger
 [2021-06-28T06:28:31Z TRACE origin::program] Program started
 [2021-06-28T06:28:31Z TRACE origin::threads] Main Thread[Pid(3916066)] initialized
 [2021-06-28T06:28:31Z TRACE origin::program] Calling `.init_array`-registered function `0x5555558fb480(1, 0x7fffffffdb98, 0x7fffffffdba8)`
@@ -140,6 +140,13 @@ Known limitations in `mustang` include:
  - Enabling LTO doesn't work yet.
  - Unwinding isn't yet implemented on 32-bit arm, and `catch_unwind` does not
    yet work on 32-bit x86.
+
+## Alternatives
+
+[Eyra] uses the same underlying libraries as Mustang, but doesn't use a custom
+target, and doesn't need `-Z build-std`. And, it supports LTO.
+
+[Eyra]: https://github.com/sunfishcode/c-ward/tree/main/eyra
 
 ## Background
 


### PR DESCRIPTION
Add a mention of the new [Eyra] project to Mustang's README. Mustang is still maintained; all of Mustang's main libraries have been factored out, so Mustang proper is now just a very thin layer that just sets up the custom target and pulls in all the needed libraries.

Eyra is using uses those same libraries, just without Mustang's custom target, so it's more convenient to use in some situations.

While here, fix the command-line example that enables the `env_logger` feature; to get log output, it's also necessary to enable the `log` feature.

[Eyra]: https://github.com/sunfishcode/c-ward/tree/main/eyra