### PR TITLE
Update to the latest c-scape, which enables unwinding features.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     env:
-      QEMU_BUILD_VERSION: 7.0.0
+      QEMU_BUILD_VERSION: 8.1.0
     strategy:
       matrix:
         build: [ubuntu, ubuntu-20.04, i686-linux, aarch64-linux, riscv64-linux]

--- a/mustang/Cargo.toml
+++ b/mustang/Cargo.toml
@@ -10,25 +10,9 @@ license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 repository = "https://github.com/sunfishcode/mustang"
 edition = "2021"
 
-# Enable "libc" and don't depend on "spin".
-# TODO: Eventually, we should propose a `fde-phdr-rustix` backend option to
-# upstream `unwinding` so that it doesn't need to go through `dl_iterate_phdr`,
-# but `fde-phdr-dl` works for now.
-[target.'cfg(all(target_vendor = "mustang", not(target_arch = "arm")))'.dependencies.unwinding]
-version = "0.2.0"
-default-features = false
-features = [
-    "unwinder",
-    "dwarf-expr",
-    "hide-trace",
-    "fde-phdr-dl",
-    "fde-registry",
-    "libc",
-]
-
 [target.'cfg(target_vendor = "mustang")'.dependencies]
 origin = { version = "0.13.0", default-features = false }
-c-gull = { version = "0.14.0", default-features = false, features = ["take-charge", "call-main", "malloc-via-rust-global-alloc", "define-mem-functions"] }
+c-gull = { version = "0.14.4", default-features = false, features = ["take-charge", "call-main", "malloc-via-rust-global-alloc", "define-mem-functions"] }
 
 # A general-purpose `global_allocator` implementation.
 rustix-dlmalloc = { version = "0.1.0", features = ["global"], optional = true }

--- a/mustang/src/lib.rs
+++ b/mustang/src/lib.rs
@@ -27,11 +27,6 @@ macro_rules! can_run_this {
 
 #[cfg(target_vendor = "mustang")]
 extern crate c_gull;
-#[cfg(target_vendor = "mustang")]
-extern crate origin;
-#[cfg(not(target_arch = "arm"))]
-#[cfg(target_vendor = "mustang")]
-extern crate unwinding;
 
 #[cfg(target_vendor = "mustang")]
 #[cfg(feature = "rustix-dlmalloc")]


### PR DESCRIPTION
Move the code from Mustang for enabling unwinding's features, as the c-scape crate how handles that automatically.

While here, update to the latest QEMU.