### PR TITLE
Remove the direct dependency on origin.

### DIFF
--- a/mustang/Cargo.toml
+++ b/mustang/Cargo.toml
@@ -11,8 +11,7 @@ repository = "https://github.com/sunfishcode/mustang"
 edition = "2021"
 
 [target.'cfg(target_vendor = "mustang")'.dependencies]
-origin = { version = "0.13.0", default-features = false }
-c-gull = { version = "0.14.4", default-features = false, features = ["take-charge", "call-main", "malloc-via-rust-global-alloc", "define-mem-functions"] }
+c-gull = { version = "0.14.5", default-features = false, features = ["take-charge", "call-main", "malloc-via-rust-global-alloc", "define-mem-functions"] }
 
 # A general-purpose `global_allocator` implementation.
 rustix-dlmalloc = { version = "0.1.0", features = ["global"], optional = true }
@@ -23,7 +22,11 @@ wee_alloc = { version = "0.4", optional = true }
 default = ["default-alloc", "thread", "std"]
 default-alloc = ["rustix-dlmalloc"]
 thread = ["c-gull/thread"]
-env_logger = ["origin/env_logger"]
-log = ["origin/log"]
-max_level_off = ["origin/max_level_off"]
+env_logger = ["c-gull/env_logger"]
+log = ["c-gull/log"]
+max_level_off = ["c-gull/max_level_off"]
 std = ["c-gull/std"]
+
+# Enable highly experimental support for performing startup-time relocations,
+# needed to support statically-linked PIE executables.
+experimental-relocate = ["c-gull/experimental-relocate"]


### PR DESCRIPTION
Just depend on c-gull, which pulls in everything it needs automatically.