### PR TITLE
Remove mustang's `global_allocator`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,7 @@ edition = "2021"
 exclude = ["/.github"]
 
 [target.'cfg(target_vendor = "mustang")'.dependencies]
-c-gull = { version = "0.14.5", default-features = false, features = ["take-charge", "call-main", "malloc-via-rust-global-alloc", "define-mem-functions"] }
-
-# A general-purpose `global_allocator` implementation.
-rustix-dlmalloc = { version = "0.1.0", features = ["global"], optional = true }
-# A small `global_allocator` implementation.
-wee_alloc = { version = "0.4", optional = true }
+c-gull = { version = "0.14.5", default-features = false, features = ["take-charge", "call-main", "malloc-via-crates", "define-mem-functions"] }
 
 [dev-dependencies]
 similar-asserts = "1.1.0"
@@ -36,8 +31,7 @@ which = "4.4.0"
 core_simd = { git = "https://github.com/rust-lang/portable-simd" }
 
 [features]
-default = ["default-alloc", "thread", "std"]
-default-alloc = ["rustix-dlmalloc"]
+default = ["thread", "std"]
 thread = ["c-gull/thread"]
 env_logger = ["c-gull/env_logger"]
 log = ["c-gull/log"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,4 @@
 #![doc = include_str!("../README.md")]
-// Enable strict-provenance APIs and lints. We only do this for mustang to
-// prevent non-mustang compilations from depending on nightly Rust.
-#![cfg_attr(target_vendor = "mustang", feature(strict_provenance))]
-#![cfg_attr(target_vendor = "mustang", deny(fuzzy_provenance_casts))]
-#![cfg_attr(target_vendor = "mustang", deny(lossy_provenance_casts))]
 #![no_std]
 
 /// Declare that a program can be compiled and run by `mustang`.
@@ -27,22 +22,3 @@ macro_rules! can_run_this {
 
 #[cfg(target_vendor = "mustang")]
 extern crate c_gull;
-
-#[cfg(target_vendor = "mustang")]
-#[cfg(feature = "rustix-dlmalloc")]
-#[global_allocator]
-static GLOBAL_ALLOCATOR: rustix_dlmalloc::GlobalDlmalloc = rustix_dlmalloc::GlobalDlmalloc;
-
-#[cfg(target_vendor = "mustang")]
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static GLOBAL_ALLOCATOR: wee_alloc::WeeAlloc<'static> = wee_alloc::WeeAlloc::INIT;
-
-// We need to enable some global allocator, because `c-scape` implements
-// `malloc` using the Rust global allocator, and the default Rust global
-// allocator uses `malloc`.
-#[cfg(target_vendor = "mustang")]
-#[cfg(not(any(feature = "rustix-dlmalloc", feature = "wee_alloc")))]
-compile_error!(
-    "Either feature \"rustix-dlmalloc\" or \"wee_alloc\" must be enabled for this crate."
-);

--- a/test-crates/mustang-nostd/Cargo.toml
+++ b/test-crates/mustang-nostd/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 # The mustang crate provides the `can_run_this!()` macro.
-mustang = { path = "../..", default-features = false, features = ["thread", "default-alloc"] }
+mustang = { path = "../..", default-features = false, features = ["thread"] }
+rustix-dlmalloc = { version = "0.1.0", features = ["global"] }
 
 [workspace]

--- a/test-crates/mustang-nostd/src/main.rs
+++ b/test-crates/mustang-nostd/src/main.rs
@@ -18,6 +18,9 @@ fn panic(_panic: &core::panic::PanicInfo<'_>) -> ! {
 #[lang = "eh_personality"]
 extern "C" fn eh_personality() {}
 
+#[global_allocator]
+static GLOBAL_ALLOCATOR: rustix_dlmalloc::GlobalDlmalloc = rustix_dlmalloc::GlobalDlmalloc;
+
 // Small hack for rust-analyzer.
 //
 // If we do `#[cfg(not(test))]` then rust-analyzer will say the code is inactive and we


### PR DESCRIPTION
Switch to c-scape's malloc-via-crates mode, in which c-scape provides `malloc` using rustix-dlmalloc directly, and Rust defaults to using `malloc`.

This removes mustang's features for different allocators, but it adds the ability for Mustang users to install their own allocators using the normal `#[global_allocator]` mechanism.