### PR TITLE
Enable LTO support.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,6 +176,13 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
+    - name: test mustang-example-lto
+      working-directory: example-crates/mustang-example-lto
+      run: |
+        cargo run -Z build-std --target=../../target-specs/${{ matrix.mustang_target }}.json --release
+      env:
+        RUST_BACKTRACE: 1
+
     - name: test mustang-nostd as program
       working-directory: example-crates/mustang-nostd
       run: |

--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ Known limitations in `mustang` include:
  - Dynamic linking isn't implemented yet.
  - Many libc C functions that aren't typically needed by most Rust programs
    aren't implemented yet.
- - Enabling LTO doesn't work yet.
 
 ## Alternatives
 
@@ -143,9 +142,8 @@ target, and doesn't need `-Z build-std`.
 
 Using [Origin] directly is another option; there are [examples] showing how
 to do this. Using origin directly can produce very small binary sizes; the
-`tiny` example can produce a 408-byte executable. Among other things, Origin
-by itself works with LTO. The big downside of using Origin directly is that
-it doesn't provide a `std` implementation.
+`tiny` example can produce a 408-byte executable. The big downside of using
+Origin directly is that it doesn't provide a `std` implementation.
 
 [Origin Studio] is a demo of what a `std`-like environment on top of Origin
 might look like. It has things like `println!`, but it's also currently lots

--- a/example-crates/mustang-example-lto/Cargo.toml
+++ b/example-crates/mustang-example-lto/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "mustang-example"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+# The mustang crate provides the `can_run_this!()` macro.
+mustang = { path = "../.." }
+
+# Enable LTO.
+[profile.release]
+lto = true
+
+# This is just an example crate, and not part of the mustang workspace.
+[workspace]

--- a/example-crates/mustang-example-lto/README.md
+++ b/example-crates/mustang-example-lto/README.md
@@ -1,0 +1,26 @@
+This crate demonstrates the use of the `mustang::can_run_this!()` macro in a
+"Hello, world" crate.
+
+When compiled for a non-mustang target, it doesn't depend on nightly Rust and
+there are no extra dependencies:
+
+```console
+$ cargo tree
+mustang-example v0.0.0 (…/example-crates/mustang-example)
+└── mustang v0.13.2 (…)
+```
+
+When compiled for a mustang target, it depends on nightly Rust and it has the
+c-gull, c-scape, and origin dependencies:
+
+```console
+$ cargo tree --target=x86_64-mustang-linux-gnu
+mustang-example v0.0.0 (…/example-crates/mustang-example)
+└── mustang v0.14.0 (…)
+    ├── c-gull v0.15.0
+    │   ├── c-scape v0.15.5
+    │   │   ├── errno v0.3.3
+    │   │   │   └── libc v0.2.148
+    │   │   ├── libc v0.2.148
+…
+```

--- a/example-crates/mustang-example-lto/src/main.rs
+++ b/example-crates/mustang-example-lto/src/main.rs
@@ -1,0 +1,5 @@
+mustang::can_run_this!();
+
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
Update to c-gull 0.15.10, which fixes LTO compatibility. Add an example that uses LTO, and test it in the example-crates test.